### PR TITLE
Allow `authorise-without-apparmor` when `aa_getpeercon()` returns `ENOPROTOOPT`

### DIFF
--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -59,7 +59,6 @@ int main(int argc, char const* argv[])
             ConfigurationOption{[&](auto& option) { background_client.set_crash_background_colour(option);},
                                "diagnostic-background", "Colour of diagnostic screen background RGB", "0x380c24"},
             ConfigurationOption{[&](auto& option) { background_client.set_crash_text_colour(option);},
-
                                "diagnostic-text",       "Colour of diagnostic screen text RGB", "0xffffff"},
             ConfigurationOption{[&] (auto& option) { background_client.set_diagnostic_path(option);},
                                "diagnostic-path",  "Path (including filename) of diagnostic file", ""},

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -59,6 +59,7 @@ int main(int argc, char const* argv[])
             ConfigurationOption{[&](auto& option) { background_client.set_crash_background_colour(option);},
                                "diagnostic-background", "Colour of diagnostic screen background RGB", "0x380c24"},
             ConfigurationOption{[&](auto& option) { background_client.set_crash_text_colour(option);},
+
                                "diagnostic-text",       "Colour of diagnostic screen text RGB", "0xffffff"},
             ConfigurationOption{[&] (auto& option) { background_client.set_diagnostic_path(option);},
                                "diagnostic-path",  "Path (including filename) of diagnostic file", ""},

--- a/src/snap_name_of.cpp
+++ b/src/snap_name_of.cpp
@@ -41,7 +41,9 @@ auto snap_name_of(miral::Application const& app, bool fallback_without_apparmor,
     {
         mir::log_info("aa_getpeercon() failed for process %d: %s", miral::pid_of(app), strerror(errno));
 
-        if ((errno == EINVAL) && fallback_without_apparmor) // EINVAL is what is returned when AppArmor isn't setup
+        // EINVAL is what is returned when AppArmor isn't setup
+        // ENOPROTOOPT is what is returned when AppArmor doesn't have some Ubuntu patches (yet)
+        if (((errno == EINVAL)|| errno == ENOPROTOOPT) && fallback_without_apparmor)
         {
             mir::log_info("Fall back (without AppArmor): Identify client via /proc/%%d/cmdline");
 

--- a/src/snap_name_of.cpp
+++ b/src/snap_name_of.cpp
@@ -43,7 +43,7 @@ auto snap_name_of(miral::Application const& app, bool fallback_without_apparmor,
 
         // EINVAL is what is returned when AppArmor isn't setup
         // ENOPROTOOPT is what is returned when AppArmor doesn't have some Ubuntu patches (yet)
-        if (((errno == EINVAL)|| errno == ENOPROTOOPT) && fallback_without_apparmor)
+        if (((errno == EINVAL) || errno == ENOPROTOOPT) && fallback_without_apparmor)
         {
             mir::log_info("Fall back (without AppArmor): Identify client via /proc/%%d/cmdline");
 


### PR DESCRIPTION
Fixes: #167