### PR TITLE
Adjusting code to account for the fact that the returned app_id no longer ends with the .desktop suffix

### DIFF
--- a/launcher/lib/services/desktop_file_manager.dart
+++ b/launcher/lib/services/desktop_file_manager.dart
@@ -103,12 +103,16 @@ class DesktopFileManager {
       return null;
     }
 
-    if (!f.path.endsWith('.desktop')) {
+    const String desktopFileSuffix = '.desktop';
+    if (!f.path.endsWith(desktopFileSuffix)) {
       return null;
     }
 
-    final desktopFile = ApplicationFileDesktopFile(
-        f.path, Uri.parse(f.path).path.split("/").last);
+    String applicationId = Uri.parse(f.path).path.split("/").last;
+    applicationId = applicationId.substring(
+        0, applicationId.length - desktopFileSuffix.length);
+
+    final desktopFile = ApplicationFileDesktopFile(f.path, applicationId);
     if (!await desktopFile.load()) {
       _logger.shout("Unable to load desktop file: ${f.path}");
       return null;


### PR DESCRIPTION
relies on https://github.com/canonical/mir/pull/3629

## What's new?
- We dont' want a `.desktop` file suffix in the applicaiton id