### PR TITLE
For testing purposes only: Disable the internal client

### DIFF
--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char const* argv[])
                                "diagnostic-path",  "Path (including filename) of diagnostic file", ""},
             ConfigurationOption{[&] (int option) { background_client.set_diagnostic_delay(option);},
                                 "diagnostic-delay", "Delay time (in seconds) before displaying diagnostic screen", 0},
-            StartupInternalClient{std::ref(background_client)},
+            // StartupInternalClient{std::ref(background_client)},
             ConfigurationOption{[&](bool option) { init_authorise_without_apparmor(option);},
                                "authorise-without-apparmor", "Use /proc/<pid>/cmdline if AppArmor is unavailable", false },
             set_window_management_policy<FrameWindowManagerPolicy>(window_manager_observer),


### PR DESCRIPTION
Part of trying to isolate the problem reported on Meteor Lake (canonical/mir/issues/3710)