### PR TITLE
Use `munmap()` correctly

### DIFF
--- a/src/background_client.cpp
+++ b/src/background_client.cpp
@@ -420,11 +420,12 @@ void BackgroundClient::Self::draw_screen(SurfaceInfo& info, bool draws_crash) co
             info.output->output);
     }
 
-    if (info.buffer)
+    if (info.buffer && info.buffer_size != stride * height)
     {
-        wl_buffer_destroy(info.buffer);
+        info.reset_buffer();
     }
 
+    if (!info.buffer)
     {
         auto const shm_pool = make_shm_pool(stride * height, &info.content_area);
 
@@ -433,6 +434,7 @@ void BackgroundClient::Self::draw_screen(SurfaceInfo& info, bool draws_crash) co
             0,
             width, height, stride,
             WL_SHM_FORMAT_ARGB8888);
+        info.buffer_size = stride * height;
     }
 
     auto buffer = static_cast<unsigned char*>(info.content_area);

--- a/src/egfullscreenclient.h
+++ b/src/egfullscreenclient.h
@@ -131,6 +131,7 @@ public:
         ~SurfaceInfo();
 
         void clear_window();
+        void reset_buffer();
 
         // Screen description
         Output const* output;
@@ -140,6 +141,7 @@ public:
         wl_surface* surface = nullptr;
         wl_shell_surface* shell_surface = nullptr;
         wl_buffer* buffer = nullptr;
+        size_t buffer_size = 0;
     };
 
     virtual void draw_screen(SurfaceInfo& info, bool draws_crash) const = 0;


### PR DESCRIPTION
We were failing to release mmapped memory (doing it wrong and at the wrong time). That lead to the memory footprint growing without bound.

C.f. https://github.com/canonical/mir/issues/3710