### PR TITLE
Update configuration documentation link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are four snap configuration options:
 * `display=<options for display layout>`
 * `launcher=[true|false]`
 
-The configuration options are described in detail in [the Ubuntu Frame reference](https://mir-server.io/docs/reference).
+The configuration options are described in detail in [the Ubuntu Frame reference](https://mir-server.io/docs/ubuntu-frame-configuration-options).
 
 ## Development
 


### PR DESCRIPTION
The previous link was to the whole reference, it is more useful to go directly to the configuration docs (it's easily navigatable to the reference if needed).