### PR TITLE
Set XDG_CURRENT_DESKTOP

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,7 @@ environment:
   XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
   # Setup diagnostic
   MIR_SERVER_DIAGNOSTIC_PATH: $SNAP_COMMON/diagnostic/diagnostic.txt
+  XDG_CURRENT_DESKTOP: UbuntuFrame:Mir
 
 layout:
   /usr/share/icons:


### PR DESCRIPTION
Set XDG_CURRENT_DESKTOP to UbuntuFrame:Mir to allow showing and hiding desktop files based on session.