### PR TITLE
Implement custom client placement

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,11 +134,13 @@ parts:
       - libboost-iostreams-dev
       - libapparmor-dev
       - libfreetype6-dev
+      - libyaml-cpp-dev
     stage-packages:
       - libboost-iostreams1.74.0
       # Stage libmiral<n> indirectly as we cannot (since core22) do `try:/else:`
       - libmiral-dev
       - xkb-data
+      - libyaml-cpp0.8
     prime:
       # Do not prime the `-dev` part of libmiral-dev, we don't need it (just the libmiral<n> dependency)
       - -usr/include

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -134,13 +134,11 @@ parts:
       - libboost-iostreams-dev
       - libapparmor-dev
       - libfreetype6-dev
-      - libyaml-cpp-dev
     stage-packages:
       - libboost-iostreams1.74.0
       # Stage libmiral<n> indirectly as we cannot (since core22) do `try:/else:`
       - libmiral-dev
       - xkb-data
-      - libyaml-cpp0.8
     prime:
       # Do not prime the `-dev` part of libmiral-dev, we don't need it (just the libmiral<n> dependency)
       - -usr/include
@@ -224,7 +222,7 @@ parts:
       if [[ "${CRAFT_ARCH_BUILD_FOR}" != @(amd64|arm64) ]]; then
         install --mode 755 --no-target-directory ubuntu_frame_launcher.fake ${CRAFT_PART_INSTALL}/ubuntu_frame_launcher
       else
-        git clone -b 3.19.6 https://github.com/flutter/flutter.git ${CRAFT_PART_BUILD}/flutter-distro
+        git clone -b 3.29.2 https://github.com/flutter/flutter.git ${CRAFT_PART_BUILD}/flutter-distro
         export PATH=${CRAFT_PART_BUILD}/flutter-distro/bin:$PATH
         flutter config --no-enable-{web,ios,android,fuchsia,windows-desktop,macos-desktop}
         flutter pub get

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,6 @@ pkg_check_modules(MIRAL miral REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
 pkg_check_modules(APPARMOR libapparmor REQUIRED)
 pkg_check_modules(FREETYPE freetype2 REQUIRED)
-pkg_check_modules(YAML REQUIRED IMPORTED_TARGET yaml-cpp)
 
 add_executable(frame
     frame_main.cpp
@@ -31,7 +30,7 @@ target_include_directories(frame
         ${MIRAL_INCLUDE_DIRS} 
     PRIVATE 
         ${FREETYPE_INCLUDE_DIRS})
-target_link_libraries(frame ${MIRAL_LDFLAGS} ${WAYLAND_CLIENT_LDFLAGS} ${APPARMOR_LDFLAGS} ${FREETYPE_LDFLAGS} ${Boost_LIBRARIES} PkgConfig::YAML)
+target_link_libraries(frame ${MIRAL_LDFLAGS} ${WAYLAND_CLIENT_LDFLAGS} ${APPARMOR_LDFLAGS} ${FREETYPE_LDFLAGS} ${Boost_LIBRARIES})
 
 install(PROGRAMS ${CMAKE_BINARY_DIR}/frame
     DESTINATION ${CMAKE_INSTALL_PREFIX}/bin

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ pkg_check_modules(MIRAL miral REQUIRED)
 pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
 pkg_check_modules(APPARMOR libapparmor REQUIRED)
 pkg_check_modules(FREETYPE freetype2 REQUIRED)
+pkg_check_modules(YAML REQUIRED IMPORTED_TARGET yaml-cpp)
 
 add_executable(frame
     frame_main.cpp
@@ -16,6 +17,7 @@ add_executable(frame
     egfullscreenclient.cpp egfullscreenclient.h
     background_client.cpp background_client.h
     snap_name_of.cpp snap_name_of.h
+    layout_metadata.cpp layout_metadata.h
 )
 
 # Check for boost
@@ -29,7 +31,7 @@ target_include_directories(frame
         ${MIRAL_INCLUDE_DIRS} 
     PRIVATE 
         ${FREETYPE_INCLUDE_DIRS})
-target_link_libraries(frame ${MIRAL_LDFLAGS} ${WAYLAND_CLIENT_LDFLAGS} ${APPARMOR_LDFLAGS} ${FREETYPE_LDFLAGS} ${Boost_LIBRARIES})
+target_link_libraries(frame ${MIRAL_LDFLAGS} ${WAYLAND_CLIENT_LDFLAGS} ${APPARMOR_LDFLAGS} ${FREETYPE_LDFLAGS} ${Boost_LIBRARIES} PkgConfig::YAML)
 
 install(PROGRAMS ${CMAKE_BINARY_DIR}/frame
     DESTINATION ${CMAKE_INSTALL_PREFIX}/bin

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -46,9 +46,9 @@ int main(int argc, char const* argv[])
 
     runner.add_stop_callback([&] { background_client.stop(); });
 
-    display_config.set_layout_userdata_builder("applications", [](std::unique_ptr<DisplayConfigurationNode> node) -> std::any
+    display_config.layout_userdata_builder("applications", [](DisplayConfiguration::Node const& node) -> std::any
     {
-        return std::make_shared<LayoutMetadata>(std::move(node));
+        return std::make_shared<LayoutMetadata>(node);
     });
     
     return runner.run_with(

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -46,9 +46,9 @@ int main(int argc, char const* argv[])
 
     runner.add_stop_callback([&] { background_client.stop(); });
 
-    display_config.set_layout_userdata_builder([](std::string const&, YAML::Node const& value) -> std::shared_ptr<void>
+    display_config.set_layout_userdata_builder([](std::string const&, std::unique_ptr<DisplayConfigurationNode> node) -> std::shared_ptr<void>
     {
-        return std::make_shared<LayoutMetadata>(value);
+        return std::make_shared<LayoutMetadata>(std::move(node));
     });
     
     return runner.run_with(

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -46,10 +46,12 @@ int main(int argc, char const* argv[])
 
     runner.add_stop_callback([&] { background_client.stop(); });
 
+#if MIRAL_MAJOR_VERSION > 5 || (MIRAL_MAJOR_VERSION == 5 && MIRAL_MINOR_VERSION >= 3)
     display_config.layout_userdata_builder("applications", [](DisplayConfiguration::Node const& node) -> std::any
     {
         return std::make_shared<LayoutMetadata>(node);
     });
+#endif
     
     return runner.run_with(
         {

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -19,6 +19,7 @@
 #include "background_client.h"
 #include "frame_authorization.h"
 #include "frame_window_manager.h"
+#include "layout_metadata.h"
 
 #include <miral/configuration_option.h>
 #include <miral/display_configuration.h>
@@ -44,6 +45,11 @@ int main(int argc, char const* argv[])
     BackgroundClient background_client(&runner, &window_manager_observer);
 
     runner.add_stop_callback([&] { background_client.stop(); });
+
+    display_config.set_layout_userdata_builder([](std::string const&, YAML::Node const& value) -> std::shared_ptr<void>
+    {
+        return LayoutMetadata::from_yaml(value);
+    });
     
     return runner.run_with(
         {

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char const* argv[])
 
     runner.add_stop_callback([&] { background_client.stop(); });
 
-    display_config.set_layout_userdata_builder([](std::string const&, std::unique_ptr<DisplayConfigurationNode> node) -> std::shared_ptr<void>
+    display_config.set_layout_userdata_builder("applications", [](std::unique_ptr<DisplayConfigurationNode> node) -> std::any
     {
         return std::make_shared<LayoutMetadata>(std::move(node));
     });

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -73,7 +73,7 @@ int main(int argc, char const* argv[])
             StartupInternalClient{std::ref(background_client)},
             ConfigurationOption{[&](bool option) { init_authorise_without_apparmor(option);},
                                "authorise-without-apparmor", "Use /proc/<pid>/cmdline if AppArmor is unavailable", false },
-            set_window_management_policy<FrameWindowManagerPolicy>(window_manager_observer),
+            set_window_management_policy<FrameWindowManagerPolicy>(window_manager_observer, display_config),
             Keymap{}
         });
 }

--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char const* argv[])
 
     display_config.set_layout_userdata_builder([](std::string const&, YAML::Node const& value) -> std::shared_ptr<void>
     {
-        return LayoutMetadata::from_yaml(value);
+        return std::make_shared<LayoutMetadata>(value);
     });
     
     return runner.run_with(

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -181,13 +181,12 @@ void FrameWindowManagerPolicy::handle_layout(
 
     auto const snap_instance_name = snap_instance_name_of(application);
     auto const surface_title = specification.name() ? specification.name() : window_info.name();
-    std::shared_ptr<LayoutMetadata> layout_metadata;
 
 #if MIRAL_MAJOR_VERSION > 5 || (MIRAL_MAJOR_VERSION == 5 && MIRAL_MINOR_VERSION >= 3)
+    std::shared_ptr<LayoutMetadata> layout_metadata;
     auto const layout_userdata = display_config.layout_userdata("applications");
     if (layout_userdata.has_value())
         layout_metadata = std::any_cast<std::shared_ptr<LayoutMetadata>>(layout_userdata.value());
-#endif
 
     // If the snap name or surface title is mapped to a particular position and size, then the surface is placed there.
     if (layout_metadata && layout_metadata->try_layout(specification, surface_title, snap_instance_name))
@@ -216,6 +215,7 @@ void FrameWindowManagerPolicy::handle_layout(
 
         return;
     }
+#endif
 
     // If the snap name or surface title is mapped to a particular output, then the surface is fullscreen on that output.
     if (assign_to_output(specification, surface_title, snap_instance_name))

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -185,6 +185,7 @@ void FrameWindowManagerPolicy::handle_layout(
     // If the snap name or surface title is mapped to a particular position and size, then the surface is placed there.
     if (layout_metadata != nullptr && layout_metadata->try_layout(specification, surface_title, snap_instance_name))
     {
+        // Let's warn if the user is placing their surface beyond the extents of all outputs
         Rectangle const extents(specification.top_left().value(), specification.size().value());
         bool found = false;
         for (auto const& output : active_outputs)
@@ -197,6 +198,15 @@ void FrameWindowManagerPolicy::handle_layout(
             mir::log_warning(R"(Surface for snap="%s" with title="%s" was placed such that it overlaps no outputs)",
                               snap_instance_name.c_str(),
                               surface_title ? surface_title.value().c_str() : "");
+
+        // Let's also warn if the user has also mapped this surface to a specific output
+        WindowSpecification throwaway_spec;
+        if (assign_to_output(throwaway_spec, surface_title, snap_instance_name))
+            mir::log_warning(R"(Surface for snap="%s" with title="%s" is mapped to both a specific position)"
+                              " and a specific card. The card mapping will be ignored.",
+                              snap_instance_name.c_str(),
+                              surface_title ? surface_title.value().c_str() : "");
+
         return;
     }
 

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -210,6 +210,7 @@ void FrameWindowManagerPolicy::handle_layout(
         snap_instance_name))
     {
         apply_fullscreen(specification);
+        apply_bespoke_fullscreen_placement(specification, window_info);
     }
 }
 

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -180,10 +180,13 @@ void FrameWindowManagerPolicy::handle_layout(
 
     auto const snap_instance_name = snap_instance_name_of(application);
     auto const surface_title = specification.name() ? specification.name() : window_info.name();
-    auto const layout_metadata = std::static_pointer_cast<LayoutMetadata>(display_config.layout_userdata());
+    auto const layout_userdata = display_config.layout_userdata("applications");
+    std::shared_ptr<LayoutMetadata> layout_metadata;
+    if (layout_userdata.has_value())
+        layout_metadata = std::any_cast<std::shared_ptr<LayoutMetadata>>(layout_userdata.value());
 
     // If the snap name or surface title is mapped to a particular position and size, then the surface is placed there.
-    if (layout_metadata != nullptr && layout_metadata->try_layout(specification, surface_title, snap_instance_name))
+    if (layout_metadata && layout_metadata->try_layout(specification, surface_title, snap_instance_name))
     {
         // Let's warn if the user is placing their surface beyond the extents of all outputs
         Rectangle const extents(specification.top_left().value(), specification.size().value());

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -183,8 +183,9 @@ void FrameWindowManagerPolicy::handle_layout(
         return;
 
     auto const snap_instance_name = snap_instance_name_of(application);
+    auto const surface_title = specification.name() ? specification.name() : window_info.name();
     auto const layout_metadata = std::static_pointer_cast<LayoutMetadata>(display_config.layout_userdata());
-    if (assign_to_output(specification, specification.name(), snap_instance_name))
+    if (assign_to_output(specification, surface_title, snap_instance_name))
     {
         if (specification.name())
         {
@@ -206,7 +207,7 @@ void FrameWindowManagerPolicy::handle_layout(
     }
     else if (layout_metadata == nullptr || !layout_metadata->try_layout(
         specification,
-        specification.name(),
+        surface_title,
         snap_instance_name))
     {
         apply_fullscreen(specification);
@@ -217,7 +218,6 @@ void FrameWindowManagerPolicy::handle_layout(
 auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info, WindowSpecification const& request)
 -> WindowSpecification
 {
-
     WindowSpecification specification = MinimalWindowManager::place_new_window(app_info, request);
     WindowInfo const window_info{};
     handle_layout(specification, app_info.application(), window_info);

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -63,7 +63,8 @@ bool can_position_be_overridden(WindowSpecification& spec, WindowInfo const& win
         case mir_window_state_hidden:
         case mir_window_state_attached:
             return false;
-        default:;
+        default:
+            break;
     }
 
     return true;
@@ -194,7 +195,7 @@ void FrameWindowManagerPolicy::handle_layout(
         for (auto const& output : active_outputs)
         {
             if (output.extents().overlaps(extents))
-                found = true;;
+                found = true;
         }
 
         if (!found)

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -181,10 +181,13 @@ void FrameWindowManagerPolicy::handle_layout(
 
     auto const snap_instance_name = snap_instance_name_of(application);
     auto const surface_title = specification.name() ? specification.name() : window_info.name();
-    auto const layout_userdata = display_config.layout_userdata("applications");
     std::shared_ptr<LayoutMetadata> layout_metadata;
+
+#if MIRAL_MAJOR_VERSION > 5 || (MIRAL_MAJOR_VERSION == 5 && MIRAL_MINOR_VERSION >= 3)
+    auto const layout_userdata = display_config.layout_userdata("applications");
     if (layout_userdata.has_value())
         layout_metadata = std::any_cast<std::shared_ptr<LayoutMetadata>>(layout_userdata.value());
+#endif
 
     // If the snap name or surface title is mapped to a particular position and size, then the surface is placed there.
     if (layout_metadata && layout_metadata->try_layout(specification, surface_title, snap_instance_name))

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -19,6 +19,7 @@
 
 #include <miral/minimal_window_manager.h>
 #include <miral/display_configuration.h>
+#include <miral/output.h>
 #include <mir_toolkit/events/enums.h>
 
 #include <memory>
@@ -126,6 +127,8 @@ private:
         std::vector<std::pair<std::string, int>> surface_title_to_output_id;
         std::vector<std::pair<std::string, int>> snap_name_to_output_id;
     } placement_mapping;
+
+    std::vector<miral::Output> active_outputs;
 
     void handle_layout(
         miral::WindowSpecification& spec,

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -18,7 +18,7 @@
 #define FRAME_WINDOW_MANAGER_H
 
 #include <miral/minimal_window_manager.h>
-
+#include <miral/display_configuration.h>
 #include <mir_toolkit/events/enums.h>
 
 #include <memory>
@@ -77,7 +77,10 @@ public:
     static std::string const surface_title;
     static std::string const snap_name;
 
-    FrameWindowManagerPolicy(miral::WindowManagerTools const& tools, WindowManagerObserver& window_manager_observer);
+    FrameWindowManagerPolicy(
+        miral::WindowManagerTools const& tools,
+        WindowManagerObserver& window_manager_observer,
+        miral::DisplayConfiguration const& display_config);
 
     auto place_new_window(miral::ApplicationInfo const& app_info, miral::WindowSpecification const& request)
     -> miral::WindowSpecification override;
@@ -105,6 +108,7 @@ public:
 private:
     WindowManagerObserver const& window_manager_observer;
     std::shared_ptr<WindowCount> window_count = std::make_shared<WindowCount>();
+    miral::DisplayConfiguration display_config;
 
     bool application_zones_have_changed = false;
     bool display_layout_has_changed = false;
@@ -115,16 +119,24 @@ private:
         void update(miral::Output const& output);
         void clear(miral::Output const& output);
 
-        void set_output_for_surface(miral::WindowSpecification& specification, mir::optional_value<std::string> const& title) const;
-        void set_output_for_snap(miral::WindowSpecification& specification, std::string_view name) const;
+        bool set_output_for_surface(miral::WindowSpecification& specification, mir::optional_value<std::string> const& title) const;
+        bool set_output_for_snap(miral::WindowSpecification& specification, std::string_view name) const;
 
     private:
         std::vector<std::pair<std::string, int>> surface_title_to_output_id;
         std::vector<std::pair<std::string, int>> snap_name_to_output_id;
     } placement_mapping;
 
-    void assign_to_output(
-        miral::WindowSpecification& specification, mir::optional_value<std::string> const& title,
+    void handle_layout(
+        miral::WindowSpecification& spec,
+        miral::Application const& application_info,
+        miral::WindowInfo const& info);
+
+    /// Try to assign the window to an output given its title and snap name.
+    /// \returns true if successfully assigned, otherwise false
+    bool assign_to_output(
+        miral::WindowSpecification& specification,
+        mir::optional_value<std::string> const& title,
         std::string_view snap_name);
 
     void apply_bespoke_fullscreen_placement(

--- a/src/layout_metadata.cpp
+++ b/src/layout_metadata.cpp
@@ -35,7 +35,7 @@ bool try_parse_vec2(miral::DisplayConfiguration::Node const& node, const char* f
 
     auto const field = node.at(field_name);
     std::vector<int> integers;
-    field.for_each([field_name, &integers](miral::DisplayConfiguration::Node const& node)
+    field.value().for_each([field_name, &integers](miral::DisplayConfiguration::Node const& node)
     {
         if (node.type() != miral::DisplayConfiguration::Node::Type::integer)
         {
@@ -126,25 +126,25 @@ std::optional<LayoutMetadata::LayoutApplicationPlacementStrategy> LayoutMetadata
     if (node.has("snap-name"))
     {
         auto const snap_name_node = node.at("snap-name");
-        if (snap_name_node.type() != miral::DisplayConfiguration::Node::Type::string)
+        if (snap_name_node.value().type() != miral::DisplayConfiguration::Node::Type::string)
         {
             mir::log_error("Invalid application strategy: snap-name is not a string");
             return std::nullopt;
         }
 
-        snap_name = snap_name_node.as_string();
+        snap_name = snap_name_node.value().as_string();
     }
     else
     {
         auto surface_title_node = node.at("surface-title");
-        if (surface_title_node.type() != miral::DisplayConfiguration::Node::Type::string)
+        if (surface_title_node.value().type() != miral::DisplayConfiguration::Node::Type::string)
         {
             mir::log_error("Invalid application strategy: surface-title is not a string");
             return std::nullopt;
         }
 
 
-        surface_title = node.at("surface-title").as_string();
+        surface_title = node.at("surface-title").value().as_string();
     }
 
     int x, y;

--- a/src/layout_metadata.cpp
+++ b/src/layout_metadata.cpp
@@ -55,15 +55,8 @@ bool try_parse_vec2(YAML::Node const& node, const char* field_name, int& x, int&
 }
 }
 
-LayoutMetadata::LayoutMetadata(std::vector<LayoutApplicationPlacementStrategy> const& applications)
-    : applications(applications)
+LayoutMetadata::LayoutMetadata(YAML::Node const& layout_node)
 {
-}
-
-std::shared_ptr<LayoutMetadata> LayoutMetadata::from_yaml(YAML::Node const& layout_node)
-{
-    std::vector<LayoutApplicationPlacementStrategy> applications;
-
     if (layout_node["applications"] && layout_node["applications"].IsSequence())
     {
         for (auto const& app_node : layout_node["applications"])
@@ -72,8 +65,6 @@ std::shared_ptr<LayoutMetadata> LayoutMetadata::from_yaml(YAML::Node const& layo
                 applications.push_back(app.value());
         }
     }
-
-    return std::make_shared<LayoutMetadata>(applications);
 }
 
 bool LayoutMetadata::try_layout(miral::WindowSpecification& specification,
@@ -94,7 +85,7 @@ bool LayoutMetadata::try_layout(miral::WindowSpecification& specification,
     return false;
 }
 
-LayoutApplicationPlacementStrategy::LayoutApplicationPlacementStrategy(
+LayoutMetadata::LayoutApplicationPlacementStrategy::LayoutApplicationPlacementStrategy(
     std::optional<std::string> const& snap_name,
     std::optional<std::string> const& surface_title,
     mir::geometry::Point const& position,
@@ -105,7 +96,7 @@ LayoutApplicationPlacementStrategy::LayoutApplicationPlacementStrategy(
       size(size)
 {}
 
-std::optional<LayoutApplicationPlacementStrategy> LayoutApplicationPlacementStrategy::from_yaml(YAML::Node const& node)
+std::optional<LayoutMetadata::LayoutApplicationPlacementStrategy> LayoutMetadata::LayoutApplicationPlacementStrategy::from_yaml(YAML::Node const& node)
 {
     if (!node["snap-name"] && !node["surface-title"])
     {

--- a/src/layout_metadata.cpp
+++ b/src/layout_metadata.cpp
@@ -16,11 +16,10 @@
 
 #include "layout_metadata.h"
 #include <mir/log.h>
-#include <miral/display_configuration.h>
 
 namespace
 {
-bool try_parse_vec2(miral::DisplayConfigurationNode const& node, const char* field_name, int& x, int& y)
+bool try_parse_vec2(miral::DisplayConfiguration::Node const& node, const char* field_name, int& x, int& y)
 {
     if (!node.at(field_name))
     {
@@ -28,11 +27,11 @@ bool try_parse_vec2(miral::DisplayConfigurationNode const& node, const char* fie
         return false;
     }
 
-    auto field = node.at(field_name);
+    auto const field = node.at(field_name);
     std::vector<int> integers;
-    field.value()->for_each([&integers](std::unique_ptr<miral::DisplayConfigurationNode> const& node)
+    field.value().for_each([&integers](miral::DisplayConfiguration::Node const& node)
     {
-        if (auto int_field = node->as_int())
+        if (auto const int_field = node.as_int())
             integers.push_back(int_field.value());
     });
 
@@ -49,11 +48,11 @@ bool try_parse_vec2(miral::DisplayConfigurationNode const& node, const char* fie
 }
 }
 
-LayoutMetadata::LayoutMetadata(std::unique_ptr<miral::DisplayConfigurationNode> applications_node)
+LayoutMetadata::LayoutMetadata(miral::DisplayConfiguration::Node const& applications_node)
 {
-    applications_node->for_each([&](std::unique_ptr<miral::DisplayConfigurationNode> node)
+    applications_node.for_each([&](miral::DisplayConfiguration::Node const& node)
     {
-        if (auto const app = LayoutApplicationPlacementStrategy::from_yaml(*node))
+        if (auto const app = LayoutApplicationPlacementStrategy::from_yaml(node))
             applications.push_back(app.value());
     });
 }
@@ -88,7 +87,7 @@ LayoutMetadata::LayoutApplicationPlacementStrategy::LayoutApplicationPlacementSt
 {}
 
 std::optional<LayoutMetadata::LayoutApplicationPlacementStrategy> LayoutMetadata::LayoutApplicationPlacementStrategy::from_yaml(
-    miral::DisplayConfigurationNode const& node)
+    miral::DisplayConfiguration::Node const& node)
 {
     if (!node.at("snap-name") && !node.at("surface-title"))
     {
@@ -108,9 +107,9 @@ std::optional<LayoutMetadata::LayoutApplicationPlacementStrategy> LayoutMetadata
     std::optional<std::string> surface_title;
 
     if (node.at("snap-name"))
-        snap_name = node.at("snap-name").value()->as_string();
+        snap_name = node.at("snap-name").value().as_string();
     else
-        surface_title = node.at("surface-title").value()->as_string();
+        surface_title = node.at("surface-title").value().as_string();
 
     int x, y;
     int w, h;

--- a/src/layout_metadata.cpp
+++ b/src/layout_metadata.cpp
@@ -74,7 +74,7 @@ bool LayoutMetadata::try_layout(miral::WindowSpecification& specification,
 {
     for (auto const& app : applications)
     {
-        if (app.snap_name == snap_name || app.surface_title == title)
+        if (app.snap_name == snap_name || (title.is_set() && app.surface_title == title))
         {
             specification.state() = mir_window_state_restored;
             specification.top_left() = app.position;

--- a/src/layout_metadata.cpp
+++ b/src/layout_metadata.cpp
@@ -14,6 +14,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <miral/version.h>
+#if MIRAL_MAJOR_VERSION > 5 || (MIRAL_MAJOR_VERSION == 5 && MIRAL_MINOR_VERSION >= 3)
 #include "layout_metadata.h"
 #include <mir/log.h>
 
@@ -162,3 +164,4 @@ std::optional<LayoutMetadata::LayoutApplicationPlacementStrategy> LayoutMetadata
         {x, y},
         {w, h});
 }
+#endif

--- a/src/layout_metadata.cpp
+++ b/src/layout_metadata.cpp
@@ -1,0 +1,144 @@
+/*
+* Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "layout_metadata.h"
+#include <yaml-cpp/yaml.h>
+#include <mir/log.h>
+
+namespace
+{
+bool try_parse_vec2(YAML::Node const& node, const char* field_name, int& x, int& y)
+{
+    if (!node[field_name])
+    {
+        mir::log_error("Invalid application strategy: '%s' is required", field_name);
+        return false;
+    }
+
+    if (!node[field_name].IsSequence())
+    {
+        mir::log_error("Invalid application strategy: '%s' must be a sequence", field_name);
+        return false;
+    }
+
+    if (node[field_name].size() != 2)
+    {
+        mir::log_error("Invalid application strategy: '%s' must have a length of 2, but has length %lu",
+            field_name, node[field_name].size());
+        return false;
+    }
+
+    try
+    {
+        x = node[field_name][0].as<int>();
+        y = node[field_name][1].as<int>();
+        return true;
+    }
+    catch (YAML::Exception const& e)
+    {
+        mir::log_error("Invalid application strategy: failed to parse %s to values %s", field_name, e.what());
+        return false;
+    }
+}
+}
+
+LayoutMetadata::LayoutMetadata(std::vector<LayoutApplicationPlacementStrategy> const& applications)
+    : applications(applications)
+{
+}
+
+std::shared_ptr<LayoutMetadata> LayoutMetadata::from_yaml(YAML::Node const& layout_node)
+{
+    std::vector<LayoutApplicationPlacementStrategy> applications;
+
+    if (layout_node["applications"] && layout_node["applications"].IsSequence())
+    {
+        for (auto const& app_node : layout_node["applications"])
+        {
+            if (auto const app = LayoutApplicationPlacementStrategy::from_yaml(app_node))
+                applications.push_back(app.value());
+        }
+    }
+
+ return std::make_shared<LayoutMetadata>(applications);
+}
+
+LayoutApplicationPlacementStrategy::LayoutApplicationPlacementStrategy(
+    std::optional<std::string> const& snap_name,
+    std::optional<std::string> const& surface_title,
+    mir::geometry::Point const& position,
+    mir::geometry::Size const& size)
+    : snap_name(snap_name),
+      surface_title(surface_title),
+      position(position),
+      size(size)
+{}
+
+std::optional<LayoutApplicationPlacementStrategy> LayoutApplicationPlacementStrategy::from_yaml(YAML::Node const& node)
+{
+    if (!node["snap-name"] && !node["surface-title"])
+    {
+        mir::log_error("Invalid application strategy: missing snap-name and surface-title. One of them"
+                       " must be provided.");
+        return std::nullopt;
+    }
+
+    if (node["snap-name"] && node["surface-title"])
+    {
+        mir::log_error("Invalid application strategy: provided both snap-name and surface-title, but"
+                       " only one of them can be provided.");
+        return std::nullopt;
+    }
+
+    std::optional<std::string> snap_name;
+    std::optional<std::string> surface_title;
+
+    if (node["snap-name"])
+    {
+        if (!node["snap-name"].IsScalar())
+        {
+            mir::log_error("Invalid application strategy: snap-name should be a string");
+            return std::nullopt;
+        }
+
+        snap_name = node["snap-name"].Scalar();
+    }
+    else
+    {
+        if (!node["surface-title"].IsScalar())
+        {
+            mir::log_error("Invalid application strategy: surface-title should be a string");
+            return std::nullopt;
+        }
+
+        surface_title = node["surface-title"].Scalar();
+    }
+
+    int x, y;
+    int w, h;
+
+    if (!try_parse_vec2(node, "position", x, y))
+        return std::nullopt;
+
+    if (!try_parse_vec2(node, "size", w, h))
+        return std::nullopt;
+
+    return LayoutApplicationPlacementStrategy(
+        snap_name,
+        surface_title,
+        {x, y},
+        {w, h});
+}

--- a/src/layout_metadata.cpp
+++ b/src/layout_metadata.cpp
@@ -73,7 +73,25 @@ std::shared_ptr<LayoutMetadata> LayoutMetadata::from_yaml(YAML::Node const& layo
         }
     }
 
- return std::make_shared<LayoutMetadata>(applications);
+    return std::make_shared<LayoutMetadata>(applications);
+}
+
+bool LayoutMetadata::try_layout(miral::WindowSpecification& specification,
+    mir::optional_value<std::string> const& title,
+    std::string_view snap_name) const
+{
+    for (auto const& app : applications)
+    {
+        if (app.snap_name == snap_name || app.surface_title == title)
+        {
+            specification.state() = mir_window_state_restored;
+            specification.top_left() = app.position;
+            specification.size() = app.size;
+            return true;
+        }
+    }
+
+    return false;
 }
 
 LayoutApplicationPlacementStrategy::LayoutApplicationPlacementStrategy(

--- a/src/layout_metadata.cpp
+++ b/src/layout_metadata.cpp
@@ -49,16 +49,13 @@ bool try_parse_vec2(miral::DisplayConfigurationNode const& node, const char* fie
 }
 }
 
-LayoutMetadata::LayoutMetadata(std::unique_ptr<miral::DisplayConfigurationNode> node)
+LayoutMetadata::LayoutMetadata(std::unique_ptr<miral::DisplayConfigurationNode> applications_node)
 {
-    if (auto const applications_node = node->at("applications"))
+    applications_node->for_each([&](std::unique_ptr<miral::DisplayConfigurationNode> node)
     {
-        applications_node.value()->for_each([&](std::unique_ptr<miral::DisplayConfigurationNode> node)
-        {
-            if (auto const app = LayoutApplicationPlacementStrategy::from_yaml(*node))
-                applications.push_back(app.value());
-        });
-    }
+        if (auto const app = LayoutApplicationPlacementStrategy::from_yaml(*node))
+            applications.push_back(app.value());
+    });
 }
 
 bool LayoutMetadata::try_layout(miral::WindowSpecification& specification,

--- a/src/layout_metadata.h
+++ b/src/layout_metadata.h
@@ -20,20 +20,15 @@
 #include <optional>
 #include <string>
 #include <vector>
-#include <memory>
 #include <mir/geometry/point.h>
 #include <mir/geometry/size.h>
 #include <miral/window_specification.h>
-
-namespace miral
-{
-class DisplayConfigurationNode;
-}
+#include <miral/display_configuration.h>
 
 class LayoutMetadata
 {
 public:
-    explicit LayoutMetadata(std::unique_ptr<miral::DisplayConfigurationNode> layout_node);
+    explicit LayoutMetadata(miral::DisplayConfiguration::Node const& layout_node);
 
     /// Try to assign the window to a positition and size based on its title and snap name.
     /// \returns true if successfully assigned, otherwise false
@@ -50,7 +45,7 @@ private:
             std::optional<std::string> const& surface_title,
             mir::geometry::Point const& position,
             mir::geometry::Size const& size);
-        static std::optional<LayoutApplicationPlacementStrategy> from_yaml(miral::DisplayConfigurationNode const& node);
+        static std::optional<LayoutApplicationPlacementStrategy> from_yaml(miral::DisplayConfiguration::Node const& node);
 
         std::optional<std::string> const snap_name;
         std::optional<std::string> const surface_title;

--- a/src/layout_metadata.h
+++ b/src/layout_metadata.h
@@ -1,0 +1,59 @@
+/*
+* Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef LAYOUT_METADATA_H
+#define LAYOUT_METADATA_H
+
+#include <optional>
+#include <string>
+#include <vector>
+#include <memory>
+#include <mir/geometry/point.h>
+#include <mir/geometry/size.h>
+
+namespace YAML
+{
+class Node;
+}
+
+class LayoutApplicationPlacementStrategy
+{
+public:
+    LayoutApplicationPlacementStrategy(
+        std::optional<std::string> const& snap_name,
+        std::optional<std::string> const& surface_title,
+        mir::geometry::Point const& position,
+        mir::geometry::Size const& size);
+    static std::optional<LayoutApplicationPlacementStrategy> from_yaml(YAML::Node const& node);
+
+    std::optional<std::string> const snap_name;
+    std::optional<std::string> const surface_title;
+    mir::geometry::Point const position;
+    mir::geometry::Size const size;
+};
+
+class LayoutMetadata
+{
+public:
+    explicit LayoutMetadata(std::vector<LayoutApplicationPlacementStrategy> const& applications);
+    static std::shared_ptr<LayoutMetadata> from_yaml(YAML::Node const& layout_node);
+
+    std::vector<LayoutApplicationPlacementStrategy> const applications;
+
+};
+
+
+#endif //LAYOUT_METADATA_H

--- a/src/layout_metadata.h
+++ b/src/layout_metadata.h
@@ -25,15 +25,15 @@
 #include <mir/geometry/size.h>
 #include <miral/window_specification.h>
 
-namespace YAML
+namespace miral
 {
-class Node;
+class DisplayConfigurationNode;
 }
 
 class LayoutMetadata
 {
 public:
-    explicit LayoutMetadata(YAML::Node const& layout_node);
+    explicit LayoutMetadata(std::unique_ptr<miral::DisplayConfigurationNode> layout_node);
 
     /// Try to assign the window to a positition and size based on its title and snap name.
     /// \returns true if successfully assigned, otherwise false
@@ -50,7 +50,7 @@ private:
             std::optional<std::string> const& surface_title,
             mir::geometry::Point const& position,
             mir::geometry::Size const& size);
-        static std::optional<LayoutApplicationPlacementStrategy> from_yaml(YAML::Node const& node);
+        static std::optional<LayoutApplicationPlacementStrategy> from_yaml(miral::DisplayConfigurationNode const& node);
 
         std::optional<std::string> const snap_name;
         std::optional<std::string> const surface_title;

--- a/src/layout_metadata.h
+++ b/src/layout_metadata.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <mir/geometry/point.h>
 #include <mir/geometry/size.h>
+#include <miral/window_specification.h>
 
 namespace YAML
 {
@@ -50,6 +51,12 @@ class LayoutMetadata
 public:
     explicit LayoutMetadata(std::vector<LayoutApplicationPlacementStrategy> const& applications);
     static std::shared_ptr<LayoutMetadata> from_yaml(YAML::Node const& layout_node);
+
+    /// Try to assign the window to a positition and size based on its title and snap name.
+    /// \returns true if successfully assigned, otherwise false
+    bool try_layout(miral::WindowSpecification& specification,
+        mir::optional_value<std::string> const& title,
+        std::string_view snap_name) const;
 
     std::vector<LayoutApplicationPlacementStrategy> const applications;
 

--- a/src/layout_metadata.h
+++ b/src/layout_metadata.h
@@ -45,7 +45,7 @@ private:
             std::optional<std::string> const& surface_title,
             mir::geometry::Point const& position,
             mir::geometry::Size const& size);
-        static std::optional<LayoutApplicationPlacementStrategy> from_yaml(miral::DisplayConfiguration::Node const& node);
+        static std::optional<LayoutApplicationPlacementStrategy> from_node(miral::DisplayConfiguration::Node const& node);
 
         std::optional<std::string> const snap_name;
         std::optional<std::string> const surface_title;

--- a/src/layout_metadata.h
+++ b/src/layout_metadata.h
@@ -17,6 +17,9 @@
 #ifndef LAYOUT_METADATA_H
 #define LAYOUT_METADATA_H
 
+#include <miral/version.h>
+#if MIRAL_MAJOR_VERSION > 5 || (MIRAL_MAJOR_VERSION == 5 && MIRAL_MINOR_VERSION >= 3)
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -58,4 +61,5 @@ private:
 };
 
 
+#endif
 #endif //LAYOUT_METADATA_H

--- a/src/layout_metadata.h
+++ b/src/layout_metadata.h
@@ -30,27 +30,10 @@ namespace YAML
 class Node;
 }
 
-class LayoutApplicationPlacementStrategy
-{
-public:
-    LayoutApplicationPlacementStrategy(
-        std::optional<std::string> const& snap_name,
-        std::optional<std::string> const& surface_title,
-        mir::geometry::Point const& position,
-        mir::geometry::Size const& size);
-    static std::optional<LayoutApplicationPlacementStrategy> from_yaml(YAML::Node const& node);
-
-    std::optional<std::string> const snap_name;
-    std::optional<std::string> const surface_title;
-    mir::geometry::Point const position;
-    mir::geometry::Size const size;
-};
-
 class LayoutMetadata
 {
 public:
-    explicit LayoutMetadata(std::vector<LayoutApplicationPlacementStrategy> const& applications);
-    static std::shared_ptr<LayoutMetadata> from_yaml(YAML::Node const& layout_node);
+    explicit LayoutMetadata(YAML::Node const& layout_node);
 
     /// Try to assign the window to a positition and size based on its title and snap name.
     /// \returns true if successfully assigned, otherwise false
@@ -58,7 +41,24 @@ public:
         mir::optional_value<std::string> const& title,
         std::string_view snap_name) const;
 
-    std::vector<LayoutApplicationPlacementStrategy> const applications;
+private:
+    class LayoutApplicationPlacementStrategy
+    {
+    public:
+        LayoutApplicationPlacementStrategy(
+            std::optional<std::string> const& snap_name,
+            std::optional<std::string> const& surface_title,
+            mir::geometry::Point const& position,
+            mir::geometry::Size const& size);
+        static std::optional<LayoutApplicationPlacementStrategy> from_yaml(YAML::Node const& node);
+
+        std::optional<std::string> const snap_name;
+        std::optional<std::string> const surface_title;
+        mir::geometry::Point const position;
+        mir::geometry::Size const size;
+    };
+
+    std::vector<LayoutApplicationPlacementStrategy> applications;
 
 };
 


### PR DESCRIPTION
Relies on https://github.com/canonical/mir/pull/3869

## What's new?
- Implemented `DisplayConfiguration::set_layout_userdata_builder` such that it builds a `LayoutMetadata`, which parses the layout display configuration into a list of application placement data
- When placing a new surface, we try and place it according to `LayoutMetadata` first. If that fails, we try to assign it to an output if it is mapped to one. Otherwise we just fullscreen it as we did before.
- Warning the user when their surface placement does not intersect any output
- Warning the user when they have specified that their surface should be placed both in a particular position and on a particular card

## To test
1. Have a `~/.config/frame.display` that looks like:
    ```yaml
    layouts:
    # keys here are layout labels (used for atomically switching between them).
    # The yaml anchor 'the_default' is used to alias the 'default' label
    
      default:
        cards:
        # a list of cards (currently matched by card-id)

        - card-id: 0
          unknown-1:
            # This output supports the following modes: 1280x1024@60.0
            #
            # Uncomment the following to enforce the selected configuration.
            # Or amend as desired.
            #
            state: enabled	# {enabled, disabled}, defaults to enabled
            mode: 1280x1024@60.0	# Defaults to preferred mode
            position: [0, 0]	# Defaults to [0, 0]
            orientation: normal	# {normal, left, right, inverted}, defaults to normal
            scale: 1
            group: 0	# Outputs with the same non-zero value are treated as a single display

        applications:
          # Two applications side by side on the first display.
          - snap-name: gedit
            position: [0, 0]
            size: [780, 1024]
          - surface-title: Mines
            position: [780, 0]
            size: [500, 1024]
    ```
2. Run frame with:
    ```
    frame --display-layout=default
    ```
3. Run `gedit` and `gnome-mines`
4. See that they are positioned correctly
5. Run another app and see that it takes up the full screen

![Screenshot from 2025-04-02 14-58-04](https://github.com/user-attachments/assets/0ca275d5-3c09-4a82-9f53-64f7962cd6f2)

## TODO Later
- For now, we are ignoring the requirement around the Z-order of applications