### PR TITLE
(#221) windows are now clipped to their tile if they are absolutely positioned and sized

### DIFF
--- a/src/frame_main.cpp
+++ b/src/frame_main.cpp
@@ -22,6 +22,7 @@
 #include "layout_metadata.h"
 
 #include <miral/configuration_option.h>
+#include <miral/decorations.h>
 #include <miral/display_configuration.h>
 #include <miral/internal_client.h>
 #include <miral/keymap.h>
@@ -76,6 +77,7 @@ int main(int argc, char const* argv[])
             ConfigurationOption{[&](bool option) { init_authorise_without_apparmor(option);},
                                "authorise-without-apparmor", "Use /proc/<pid>/cmdline if AppArmor is unavailable", false },
             set_window_management_policy<FrameWindowManagerPolicy>(window_manager_observer, display_config),
-            Keymap{}
+            Keymap{},
+            miral::Decorations::always_csd()
         });
 }

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -173,7 +173,7 @@ bool FrameWindowManagerPolicy::handle_keyboard_event(MirKeyboardEvent const* eve
 void FrameWindowManagerPolicy::handle_layout(
     WindowSpecification& specification,
     Application const& application,
-    WindowInfo const& window_info)
+    WindowInfo& window_info)
 {
     // If a window's position cannot be overridden, we return the requested spec.
     if (!can_position_be_overridden(specification, window_info))
@@ -213,6 +213,8 @@ void FrameWindowManagerPolicy::handle_layout(
                               snap_instance_name.c_str(),
                               surface_title ? surface_title.value().c_str() : "");
 
+        if (window_info.window())
+            window_info.clip_area(extents);
         return;
     }
 #endif
@@ -250,7 +252,7 @@ auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info,
 -> WindowSpecification
 {
     WindowSpecification specification = MinimalWindowManager::place_new_window(app_info, request);
-    WindowInfo const window_info{};
+    WindowInfo window_info{};
     handle_layout(specification, app_info.application(), window_info);
 
     // TODO This is a hack to ensure the wallpaper remains in the background
@@ -262,6 +264,34 @@ auto FrameWindowManagerPolicy::place_new_window(ApplicationInfo const& app_info,
     }
 
     return specification;
+}
+
+void FrameWindowManagerPolicy::handle_window_ready(WindowInfo& window_info)
+{
+#if MIRAL_MAJOR_VERSION > 5 || (MIRAL_MAJOR_VERSION == 5 && MIRAL_MINOR_VERSION >= 3)
+    // After a window has been placed at a specific coordinate, we must clip it to its tile
+    // so that it does not overlap with other applications in the event that the client insists on
+    // submitting buffers that are larger than its tile.
+    auto const application = window_info.window().application();
+    auto const snap_instance_name = snap_instance_name_of(application);
+    auto const surface_title = window_info.name();
+
+    std::shared_ptr<LayoutMetadata> layout_metadata;
+    auto const layout_userdata = display_config.layout_userdata("applications");
+    if (layout_userdata.has_value())
+        layout_metadata = std::any_cast<std::shared_ptr<LayoutMetadata>>(layout_userdata.value());
+
+    // If the snap name or surface title is mapped to a particular position and size, then the surface is placed there.
+    WindowSpecification specification;
+    if (layout_metadata && layout_metadata->try_layout(specification, surface_title, snap_instance_name))
+    {
+        Rectangle const extents(specification.top_left().value(), specification.size().value());
+        window_info.clip_area(extents);
+    }
+#else
+    (void)window_info;
+#endif
+    MinimalWindowManager::handle_window_ready(window_info);
 }
 
 bool FrameWindowManagerPolicy::assign_to_output(

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -86,6 +86,8 @@ public:
     auto place_new_window(miral::ApplicationInfo const& app_info, miral::WindowSpecification const& request)
     -> miral::WindowSpecification override;
 
+    void handle_window_ready(miral::WindowInfo& window_info) override;
+
     bool handle_keyboard_event(MirKeyboardEvent const* event) override;
     void handle_modify_window(miral::WindowInfo& window_info, miral::WindowSpecification const& modifications) override;
 
@@ -133,7 +135,7 @@ private:
     void handle_layout(
         miral::WindowSpecification& spec,
         miral::Application const& application_info,
-        miral::WindowInfo const& info);
+        miral::WindowInfo& info);
 
     /// Try to assign the window to an output given its title and snap name.
     /// \returns true if successfully assigned, otherwise false

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -28,6 +28,8 @@
 
 using namespace mir::geometry;
 
+class LayoutMetadata;
+
 class WindowCount
 {
 public:
@@ -147,6 +149,11 @@ private:
     void apply_bespoke_fullscreen_placement(
         miral::WindowSpecification& specification,
         miral::WindowInfo const& window_info) const;
+
+    bool try_position_exactly(
+        miral::WindowSpecification& spec,
+        std::string const& snap_instance_name,
+        std::string const& surface_title) const;
 };
 
 #endif /* FRAME_WINDOW_MANAGER_H */


### PR DESCRIPTION
fixes #221 

## Problem
- Some clients will not abide by our wishes for them to be a particular size

## Solution
- Even if the buffer is too large, we set the clip area accordingly so that the client at least does not overflow outside of the tile