### PR TITLE
Enable testing in CI and writing initial end-to-end tests

### DIFF
--- a/.github/workflows/tics.yml
+++ b/.github/workflows/tics.yml
@@ -41,6 +41,11 @@ jobs:
           libfreetype6-dev \
           libmiral-dev \
           libmirserver-dev \
+          libmirserver-internal-dev \
+          libmircommon-dev \
+          libmircommon-internal-dev \
+          mirtest-dev \
+          mir-wlcs-integration \
           libwayland-dev \
           ninja-build \
           pkg-config

--- a/src/frame_window_manager.cpp
+++ b/src/frame_window_manager.cpp
@@ -157,10 +157,10 @@ std::string const FrameWindowManagerPolicy::snap_name = "snap-name";
 FrameWindowManagerPolicy::FrameWindowManagerPolicy(
     WindowManagerTools const& tools,
     WindowManagerObserver& window_manager_observer,
-    miral::DisplayConfiguration const& display_config)
+    std::shared_ptr<LayoutDataAccessor> const& accessor)
     : MinimalWindowManager{tools},
       window_manager_observer{window_manager_observer},
-      display_config{display_config}
+      accessor{accessor}
 {
     window_manager_observer.set_weak_window_count(window_count);
 }
@@ -523,11 +523,7 @@ bool FrameWindowManagerPolicy::try_position_exactly(
     std::string const& surface_title) const
 {
     /// Retrieve the layout information from the "applications" key in the layout's userdata.
-    std::shared_ptr<LayoutMetadata> layout_metadata;
-    auto const layout_userdata = display_config.layout_userdata("applications");
-    if (layout_userdata.has_value())
-        layout_metadata = std::any_cast<std::shared_ptr<LayoutMetadata>>(layout_userdata.value());
-
+    std::shared_ptr<LayoutMetadata> const layout_metadata = accessor->layout_metadata();
     if (layout_metadata && layout_metadata->try_layout(spec, surface_title, snap_instance_name))
         return true;
 

--- a/src/frame_window_manager.h
+++ b/src/frame_window_manager.h
@@ -18,7 +18,6 @@
 #define FRAME_WINDOW_MANAGER_H
 
 #include <miral/minimal_window_manager.h>
-#include <miral/display_configuration.h>
 #include <miral/output.h>
 #include <mir_toolkit/events/enums.h>
 
@@ -72,6 +71,13 @@ private:
     std::weak_ptr<WindowCount> weak_window_count;
 };
 
+class LayoutDataAccessor
+{
+public:
+    virtual ~LayoutDataAccessor() = default;
+    virtual std::shared_ptr<LayoutMetadata> layout_metadata() = 0;
+};
+
 class FrameWindowManagerPolicy : public miral::MinimalWindowManager
 {
 public:
@@ -83,7 +89,7 @@ public:
     FrameWindowManagerPolicy(
         miral::WindowManagerTools const& tools,
         WindowManagerObserver& window_manager_observer,
-        miral::DisplayConfiguration const& display_config);
+        std::shared_ptr<LayoutDataAccessor> const& accessor);
 
     auto place_new_window(miral::ApplicationInfo const& app_info, miral::WindowSpecification const& request)
     -> miral::WindowSpecification override;
@@ -113,7 +119,7 @@ public:
 private:
     WindowManagerObserver const& window_manager_observer;
     std::shared_ptr<WindowCount> window_count = std::make_shared<WindowCount>();
-    miral::DisplayConfiguration display_config;
+    std::shared_ptr<LayoutDataAccessor> accessor;
 
     bool application_zones_have_changed = false;
     bool display_layout_has_changed = false;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,15 +7,24 @@ include_directories(
 find_package(PkgConfig)
 pkg_check_modules(MIRAL miral REQUIRED)
 pkg_check_modules(MIRSERVER mirserver REQUIRED)
+pkg_check_modules(MIRTEST mirtest REQUIRED)
+pkg_check_modules(MIRCOMMON mircommon REQUIRED)
+pkg_check_modules(MIRCOMMON_INTERNAL REQUIRED mircommon-internal)
+pkg_check_modules(MIRSERVER_INTERNAL REQUIRED mirserver-internal)
 find_package(GTest REQUIRED)
 
 add_executable(ubuntu-frame-tests
     test_frame_authorization.cpp
+    test_frame_window_manager.cpp
 )
 
 target_include_directories(ubuntu-frame-tests PUBLIC SYSTEM
     ${MIRAL_INCLUDE_DIRS}
     ${MIRSERVER_INCLUDE_DIRS}
+    ${MIRSERVER_INTERNAL_INCLUDE_DIRS}
+    ${MIRCOMMON_INCLUDE_DIRS}
+    ${MIRCOMMON_INTERNAL_INCLUDE_DIRS}
+    ${MIRTEST_INCLUDE_DIRS}
     ${GTEST_INCLUDE_DIRS}
     ${GMOCK_INCLUDE_DIRS}
 )
@@ -24,6 +33,10 @@ target_link_libraries(ubuntu-frame-tests
     frame-implementation
     ${MIRAL_LDFLAGS}
     ${MIRSERVER_LDFLAGS}
+    ${MIRSERVER_INTERNAL_LDFLAGS_DIRS}
+    ${MIRCOMMON_LDFLAGS_DIRS}
+    ${MIRCOMMON_INTERNAL_LDFLAGS_DIRS}
+    ${MIRTEST_LDFLAGS}
     GTest::GTest
     GTest::Main
     GTest::gmock

--- a/src/tests/test_frame_window_manager.cpp
+++ b/src/tests/test_frame_window_manager.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "frame_window_manager.h"
+
+#include <mir_test_framework/window_management_test_harness.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+using namespace testing;
+namespace mtf = mir_test_framework;
+namespace geom = mir::geometry;
+
+namespace
+{
+auto constexpr DISPLAY_RECT = geom::Rectangle({0, 0}, {800, 600});
+
+class MockLayoutDataAccessor : public LayoutDataAccessor
+{
+public:
+    MOCK_METHOD(std::shared_ptr<LayoutMetadata>, layout_metadata, (), (override));
+};
+}
+
+class FrameWindowManagerTest : public mtf::WindowManagementTestHarness
+{
+public:
+    FrameWindowManagerTest()
+    {
+        ON_CALL(*mock_layout_data_accessor, layout_metadata()).WillByDefault(testing::Return(nullptr));
+    }
+    auto get_builder() -> mir_test_framework::WindowManagementPolicyBuilder override
+    {
+        return [&](miral::WindowManagerTools const& tools)
+        {
+            return std::make_unique<FrameWindowManagerPolicy>(
+                tools,
+                observer,
+                mock_layout_data_accessor);
+        };
+    }
+
+    auto get_initial_output_configs() -> std::vector<mir::graphics::DisplayConfigurationOutput> override
+    {
+        auto r = output_configs_from_output_rectangles({DISPLAY_RECT});
+        return r;
+    }
+
+    WindowManagerObserver observer;
+    std::shared_ptr<MockLayoutDataAccessor> mock_layout_data_accessor
+        = std::make_shared<NiceMock<MockLayoutDataAccessor>>();
+};
+
+TEST_F(FrameWindowManagerTest, NewWindowsAreFullscreenByDefault)
+{
+    auto const app = open_application("test");
+    miral::WindowSpecification const spec;
+    auto const window = create_window(app, spec);
+    auto const& info = tools().info_for(window);
+    EXPECT_THAT(info.state(), Eq(mir_window_state_fullscreen));
+}
+
+TEST_F(FrameWindowManagerTest, NewWindowsTakeUpFullSizeOfDisplay)
+{
+    auto const app = open_application("test");
+    miral::WindowSpecification const spec;
+    auto const window = create_window(app, spec);
+    EXPECT_THAT(window.top_left(), Eq(DISPLAY_RECT.top_left));
+    EXPECT_THAT(window.size(), Eq(DISPLAY_RECT.size));
+}


### PR DESCRIPTION
## What's new?
- Implemented initial end-to-end tests for the `FrameWindowManagerPolicy`
- Linked to the right libraries in `CMakeLists.txt` to compile the testing code
- Updated the `tics.yml` workflow to run the tets