### PR TITLE
Fix incorrect count of number of options.

### DIFF
--- a/docs/reference/ubuntu-frame-configuration-options.md
+++ b/docs/reference/ubuntu-frame-configuration-options.md
@@ -10,7 +10,7 @@ ______________________________________________________________________
 
 ## Snap configuration options
 
-There are three snap configuration options:
+There are four snap configuration options:
 
 - `daemon=[true|false]` enables the daemon (defaults to true on Ubuntu Core and false on classic systems)
 - `launcher=[true|false]` enables a side bar application switcher if your solution calls for that


### PR DESCRIPTION
"First shalt thou take out the Holy Pin.
 Then shalt thou count to three, no more, no less.
 Three shall be the number thou shalt count, and the number of the counting shall be three.
 Four shalt thou not count, neither count thou two, excepting that thou then proceed to three.
 Five is right out.
 Once the number three, being the third number, be reached, then lobbest thou thy Holy Hand Grenade of Antioch towards thy foe, who, being naughty in My sight, shall snuff it."