### PR TITLE
launcher: add support for head/tail options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are four snap configuration options:
 - `daemon=[true|false]` enables the daemon (defaults to false on classic systems)
 - `config=<options for the shell>`
 - `display=<options for display layout>`
-- `launcher=[true|false]`
+- `launcher=<object>` enables a side bar application switcher (defaults to `{"head":[],"tail":[]}`)
 
 The configuration options are described in detail in [the Ubuntu Frame reference](https://mir-server.io/docs/ubuntu-frame-configuration-options).
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are four snap configuration options:
 - `daemon=[true|false]` enables the daemon (defaults to false on classic systems)
 - `config=<options for the shell>`
 - `display=<options for display layout>`
-- `launcher=<object>` enables a side bar application switcher (defaults to `{"head":[],"tail":[]}`)
+- `launcher=<object>` enables a side bar application switcher (defaults to `{"head":[],"body":[],"tail":[]}`)
 
 The configuration options are described in detail in [the Ubuntu Frame reference](https://mir-server.io/docs/ubuntu-frame-configuration-options).
 

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -147,6 +147,7 @@ renderer
 renderers
 runtime
 scp
+scrollable
 scummvm
 shm
 snapcraft

--- a/docs/reference/configuring-ubuntu-frame-through-a-gadget-snap.md
+++ b/docs/reference/configuring-ubuntu-frame-through-a-gadget-snap.md
@@ -26,7 +26,12 @@ defaults:
       add-wayland-extensions=zwp_pointer_constraints_v1:zwp_relative_pointer_manager_v1
     daemon: true
     launcher:
-      tail: magnifier,cursor-scale,output-filter
+      head:
+        - running
+      tail:
+        - magnifier
+        - cursor-scale
+        - output-filter
 ```
 
 See {ref}`ubuntu-frame-configuration-options` for the reference on available options.

--- a/docs/reference/configuring-ubuntu-frame-through-a-gadget-snap.md
+++ b/docs/reference/configuring-ubuntu-frame-through-a-gadget-snap.md
@@ -27,9 +27,10 @@ defaults:
     daemon: true
     launcher:
       head:
+        - magnifier
+      body:
         - running
       tail:
-        - magnifier
         - cursor-scale
         - output-filter
 ```

--- a/docs/reference/ubuntu-frame-configuration-options.md
+++ b/docs/reference/ubuntu-frame-configuration-options.md
@@ -58,16 +58,18 @@ This controls whether a side bar application switcher ("Launcher" from Unity Des
 
 The arrays are rendered at the top (`head`), middle (`body`) and bottom (`tail`) of the sidebar. `head` and `tail` items remain static (pinned to the top and bottom respectively), while `body` items occupy the remaining space and scroll as a group when they overflow it. Each array is an ordered list of item IDs:
 
-| ID              | Description                                                       |
-| --------------- | ----------------------------------------------------------------- |
-| `running`       | Running applications; only valid in `body`, takes remaining space |
-| `magnifier`     | Magnifier toggle                                                  |
-| `cursor-scale`  | Cursor size cycle                                                 |
-| `output-filter` | Display colour filter cycle                                       |
+| ID              | Description                                              |
+| --------------- | -------------------------------------------------------- |
+| `running`       | Running applications (scrollable, takes remaining space) |
+| `magnifier`     | Magnifier toggle                                         |
+| `cursor-scale`  | Cursor size cycle                                        |
+| `output-filter` | Display colour filter cycle                              |
 
 ```{note}
-`running` is only supported in the `body` array, where it fills the remaining
-space and scrolls. A `running` entry placed in `head` or `tail` is ignored.
+`running` is best placed in `body`, where it fills the remaining space and
+scrolls. You can also place it in `head` or `tail`, but those sections are not
+height-constrained, so a long list of running apps may overflow the sidebar —
+use it there at your own risk.
 ```
 
 ```bash
@@ -84,14 +86,11 @@ Make sure that the applications you want to run are annotated with metadata and 
 Since version **211**, you can use `Mir` or `UbuntuFrame` in [`OnlyShowIn=` and `NotShowIn=`](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html) to control visibility of the icon on different environments. This is useful to hide the daemon app in snaps that are also useful outside of the Frame ecosystem.
 ```
 
-You can also place accessibility options in any section and mix them with the `running` body section:
+You can also place accessibility options in any section and mix them with `running`:
 
 ```bash
-# Running apps in the body, accessibility controls pinned at the bottom
+# Scrolling running apps in the body, accessibility controls pinned at the bottom
 $ snap set ubuntu-frame 'launcher={"head":[],"body":["running"],"tail":["magnifier","cursor-scale"]}'
-
-# Accessibility controls pinned at the top, running apps in the body
-$ snap set ubuntu-frame 'launcher={"head":["magnifier"],"body":["running"],"tail":[]}'
 
 # Static controls pinned top and bottom, scrolling running apps in the middle
 $ snap set ubuntu-frame 'launcher={"head":["magnifier"],"body":["running"],"tail":["cursor-scale"]}'

--- a/docs/reference/ubuntu-frame-configuration-options.md
+++ b/docs/reference/ubuntu-frame-configuration-options.md
@@ -58,12 +58,12 @@ This controls whether a side bar application switcher ("Launcher" from Unity Des
 
 The arrays are rendered at the top (`head`), middle (`body`) and bottom (`tail`) of the sidebar. `head` and `tail` items remain static (pinned to the top and bottom respectively), while `body` items occupy the remaining space and scroll as a group when they overflow it. Each array is an ordered list of item IDs:
 
-| ID              | Description                                                        |
+| ID              | Description                                                       |
 | --------------- | ----------------------------------------------------------------- |
 | `running`       | Running applications; only valid in `body`, takes remaining space |
-| `magnifier`     | Magnifier toggle                                                   |
-| `cursor-scale`  | Cursor size cycle                                                  |
-| `output-filter` | Display colour filter cycle                                        |
+| `magnifier`     | Magnifier toggle                                                  |
+| `cursor-scale`  | Cursor size cycle                                                 |
+| `output-filter` | Display colour filter cycle                                       |
 
 ```{note}
 `running` is only supported in the `body` array, where it fills the remaining

--- a/docs/reference/ubuntu-frame-configuration-options.md
+++ b/docs/reference/ubuntu-frame-configuration-options.md
@@ -19,10 +19,9 @@ ______________________________________________________________________
 There are four snap configuration options:
 
 - `daemon=[true|false]` enables the daemon (defaults to true on Ubuntu Core and false on classic systems)
-- `launcher=[true|false|<object>]` enables a side bar application switcher if your solution calls for that;
-  if set to an object, the following will add one or more accessibility options at the bottom of it:
+- `launcher=<object>` enables a side bar application switcher; the launcher is active when either `head` or `tail` is non-empty:
   ```json
-  { "tail": ["magnifier", "cursor-scale", "output-filter"] }
+  { "head": ["running"], "tail": ["magnifier", "cursor-scale", "output-filter"] }
   ```
 - `config=<contents for frame.config>`
 - `display=<contents for frame.display>`
@@ -55,17 +54,23 @@ This feature is only available on **Intel**, **AMD** and **ARM64** systems
 This feature is only available from Frame version **187** onward
 ```
 
-This controls whether a side bar application switcher ("Launcher" from Unity Desktop design) is displayed. If your solution requires multiple applications that the user needs to be able to switch between, this will enable that - displaying a side bar with clickable application icons.
+This controls whether a side bar application switcher ("Launcher" from Unity Desktop design) is displayed. The launcher is configured as a JSON object with `head` and `tail` arrays; it is active when either array is non-empty.
+
+The arrays are rendered at the top (`head`) and bottom (`tail`) of the sidebar. Each array is an ordered list of item IDs:
+
+| ID              | Description                                              |
+| --------------- | -------------------------------------------------------- |
+| `running`       | Running applications (scrollable, takes remaining space) |
+| `magnifier`     | Magnifier toggle                                         |
+| `cursor-scale`  | Cursor size cycle                                        |
+| `output-filter` | Display colour filter cycle                              |
 
 ```bash
-# Until https://github.com/canonical/snapd/pull/14331 gets released
-$ snap refresh snapd --channel edge/ubuntu-core-desktop
-
 # Give Frame access to application metadata and icons
 $ snap connect ubuntu-frame:desktop-launch
 
-# Enable the launcher
-$ snap set ubuntu-frame launcher=true
+# Enable the launcher with running apps at the top
+$ snap set ubuntu-frame 'launcher={"head":["running"],"tail":[]}'
 ```
 
 Make sure that the applications you want to run are annotated with metadata and icons appropriately, see Snapcraft's {ref}`snapcraft:how-to-configure-package-information` documentation to get your app icons to display.
@@ -74,21 +79,20 @@ Make sure that the applications you want to run are annotated with metadata and 
 Since version **211**, you can use `Mir` or `UbuntuFrame` in [`OnlyShowIn=` and `NotShowIn=`](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html) to control visibility of the icon on different environments. This is useful to hide the daemon app in snaps that are also useful outside of the Frame ecosystem.
 ```
 
-The launcher also supports an accessibility panel at the bottom. To enable it, pass a JSON object with a `tail` array containing any combination of `magnifier`, `cursor-scale`, and `output-filter`:
+You can also place accessibility options in either section and mix them with `running`:
 
 ```bash
-# Show only the magnifier and cursor scale options
-$ snap set ubuntu-frame launcher='{ "tail": [ "magnifier", "cursor-scale" ] }'
-```
+# Running apps at top, accessibility controls at bottom
+$ snap set ubuntu-frame 'launcher={"head":["running"],"tail":["magnifier","cursor-scale"]}'
 
-Once set to an object, you can also access / modify it via the `launcher.tail` key as a comma-separated list:
+# Accessibility controls at top, running apps at bottom
+$ snap set ubuntu-frame 'launcher={"head":["magnifier"],"tail":["running"]}'
 
-```
-# Show all accessibility options
-$ snap set ubuntu-frame launcher.tail=magnifier,cursor-scale,output-filter
+# Accessibility only (no running apps section)
+$ snap set ubuntu-frame 'launcher={"head":[],"tail":["magnifier","cursor-scale","output-filter"]}'
 
-# Disable the accessibility panel (empty tail)
-$ snap set ubuntu-frame launcher.tail=
+# Disable the launcher (both arrays empty)
+$ snap set ubuntu-frame 'launcher={"head":[],"tail":[]}'
 ```
 
 ### `config`

--- a/docs/reference/ubuntu-frame-configuration-options.md
+++ b/docs/reference/ubuntu-frame-configuration-options.md
@@ -19,9 +19,9 @@ ______________________________________________________________________
 There are four snap configuration options:
 
 - `daemon=[true|false]` enables the daemon (defaults to true on Ubuntu Core and false on classic systems)
-- `launcher=<object>` enables a side bar application switcher; the launcher is active when either `head` or `tail` is non-empty:
+- `launcher=<object>` enables a side bar application switcher; the launcher is active when any of `head`, `body` or `tail` is non-empty:
   ```json
-  { "head": ["running"], "tail": ["magnifier", "cursor-scale", "output-filter"] }
+  { "head": ["magnifier"], "body": ["running"], "tail": ["cursor-scale", "output-filter"] }
   ```
 - `config=<contents for frame.config>`
 - `display=<contents for frame.display>`
@@ -54,23 +54,28 @@ This feature is only available on **Intel**, **AMD** and **ARM64** systems
 This feature is only available from Frame version **187** onward
 ```
 
-This controls whether a side bar application switcher ("Launcher" from Unity Desktop design) is displayed. The launcher is configured as a JSON object with `head` and `tail` arrays; it is active when either array is non-empty.
+This controls whether a side bar application switcher ("Launcher" from Unity Desktop design) is displayed. The launcher is configured as a JSON object with `head`, `body` and `tail` arrays; it is active when any array is non-empty.
 
-The arrays are rendered at the top (`head`) and bottom (`tail`) of the sidebar. Each array is an ordered list of item IDs:
+The arrays are rendered at the top (`head`), middle (`body`) and bottom (`tail`) of the sidebar. `head` and `tail` items remain static (pinned to the top and bottom respectively), while `body` items occupy the remaining space and scroll as a group when they overflow it. Each array is an ordered list of item IDs:
 
-| ID              | Description                                              |
-| --------------- | -------------------------------------------------------- |
-| `running`       | Running applications (scrollable, takes remaining space) |
-| `magnifier`     | Magnifier toggle                                         |
-| `cursor-scale`  | Cursor size cycle                                        |
-| `output-filter` | Display colour filter cycle                              |
+| ID              | Description                                                        |
+| --------------- | ----------------------------------------------------------------- |
+| `running`       | Running applications; only valid in `body`, takes remaining space |
+| `magnifier`     | Magnifier toggle                                                   |
+| `cursor-scale`  | Cursor size cycle                                                  |
+| `output-filter` | Display colour filter cycle                                        |
+
+```{note}
+`running` is only supported in the `body` array, where it fills the remaining
+space and scrolls. A `running` entry placed in `head` or `tail` is ignored.
+```
 
 ```bash
 # Give Frame access to application metadata and icons
 $ snap connect ubuntu-frame:desktop-launch
 
-# Enable the launcher with running apps at the top
-$ snap set ubuntu-frame 'launcher={"head":["running"],"tail":[]}'
+# Enable the launcher with the running apps section
+$ snap set ubuntu-frame 'launcher={"head":[],"body":["running"],"tail":[]}'
 ```
 
 Make sure that the applications you want to run are annotated with metadata and icons appropriately, see Snapcraft's {ref}`snapcraft:how-to-configure-package-information` documentation to get your app icons to display.
@@ -79,20 +84,23 @@ Make sure that the applications you want to run are annotated with metadata and 
 Since version **211**, you can use `Mir` or `UbuntuFrame` in [`OnlyShowIn=` and `NotShowIn=`](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html) to control visibility of the icon on different environments. This is useful to hide the daemon app in snaps that are also useful outside of the Frame ecosystem.
 ```
 
-You can also place accessibility options in either section and mix them with `running`:
+You can also place accessibility options in any section and mix them with the `running` body section:
 
 ```bash
-# Running apps at top, accessibility controls at bottom
-$ snap set ubuntu-frame 'launcher={"head":["running"],"tail":["magnifier","cursor-scale"]}'
+# Running apps in the body, accessibility controls pinned at the bottom
+$ snap set ubuntu-frame 'launcher={"head":[],"body":["running"],"tail":["magnifier","cursor-scale"]}'
 
-# Accessibility controls at top, running apps at bottom
-$ snap set ubuntu-frame 'launcher={"head":["magnifier"],"tail":["running"]}'
+# Accessibility controls pinned at the top, running apps in the body
+$ snap set ubuntu-frame 'launcher={"head":["magnifier"],"body":["running"],"tail":[]}'
+
+# Static controls pinned top and bottom, scrolling running apps in the middle
+$ snap set ubuntu-frame 'launcher={"head":["magnifier"],"body":["running"],"tail":["cursor-scale"]}'
 
 # Accessibility only (no running apps section)
-$ snap set ubuntu-frame 'launcher={"head":[],"tail":["magnifier","cursor-scale","output-filter"]}'
+$ snap set ubuntu-frame 'launcher={"head":[],"body":[],"tail":["magnifier","cursor-scale","output-filter"]}'
 
-# Disable the launcher (both arrays empty)
-$ snap set ubuntu-frame 'launcher={"head":[],"tail":[]}'
+# Disable the launcher (all arrays empty)
+$ snap set ubuntu-frame 'launcher={"head":[],"body":[],"tail":[]}'
 ```
 
 ### `config`

--- a/launcher/lib/controllers/accessibility_controller.dart
+++ b/launcher/lib/controllers/accessibility_controller.dart
@@ -22,7 +22,6 @@ import 'package:logging/logging.dart';
 import 'package:ubuntu_frame_launcher/models/accessibility_option.dart';
 
 class AccessibilityController {
-  static const optionsEnvKey = 'UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_OPTIONS';
   static const _accessibilityConfigKey =
       "UBUNTU_FRAME_ACCESSIBILITY_CONFIG_PATH";
   static final allOptions = [
@@ -51,30 +50,18 @@ class AccessibilityController {
 
   AccessibilityController._({required this.options});
 
-  static List<AccessibilityOption> _getActiveOptions() {
-    final optionsEnv = Platform.environment[optionsEnvKey];
-
-    // Not set, show all
-    if (optionsEnv == null) {
-      return allOptions;
-    }
-
-    // Set to be explicitly empty
-    if (optionsEnv.isEmpty) {
-      return [];
-    }
-
-    final activeOptions = <AccessibilityOption>[];
-    for (final id in optionsEnv.split(',')) {
-      final optionIndex = allOptions.indexWhere((o) => o.id == id);
-      if (optionIndex != -1) {
-        activeOptions.add(allOptions[optionIndex]);
-      } else {
-        _logger.warning('$optionsEnvKey: unknown option "$id", skipping');
-      }
-    }
-
-    return activeOptions;
+  static List<AccessibilityOption> _resolveOptions(List<String> activeOptionIds) {
+    return activeOptionIds
+        .map((id) {
+          final index = allOptions.indexWhere((o) => o.id == id);
+          if (index == -1) {
+            _logger.warning('Unknown accessibility option "$id", skipping');
+            return null;
+          }
+          return allOptions[index];
+        })
+        .whereType<AccessibilityOption>()
+        .toList();
   }
 
   static Future<List<AccessibilityOption>> _loadActiveOptionValues(
@@ -130,9 +117,9 @@ class AccessibilityController {
   /// Reads the accessibility config file on disk and sets each option's
   /// current value. Options absent from the file, or with an unrecognised
   /// value, are left at their default (index 0).
-  static Future<AccessibilityController> create() async {
+  static Future<AccessibilityController> create(List<String> activeOptionIds) async {
     final activeOptions = _loadActiveOptionValues(
-        AccessibilityController._getActiveOptions(), _configPath);
+        AccessibilityController._resolveOptions(activeOptionIds), _configPath);
     return AccessibilityController._(options: await activeOptions);
   }
 

--- a/launcher/lib/main.dart
+++ b/launcher/lib/main.dart
@@ -24,6 +24,7 @@ import 'views/dock.dart';
 import 'controllers/application_controller.dart';
 import 'package:logging/logging.dart';
 import 'package:ubuntu_frame_launcher/controllers/accessibility_controller.dart';
+import 'package:ubuntu_frame_launcher/models/launcher_config.dart';
 
 void main() async {
   Logger.root.level = Level.ALL; // defaults to Level.INFO
@@ -51,9 +52,12 @@ void main() async {
           getIt.get<WindowService>(), getIt.get<DesktopFileManager>()));
   getIt.registerLazySingleton<WindowController>(
       () => WindowController(getIt.get<WindowService>()));
+  getIt.registerLazySingleton<LauncherConfig>(
+      () => LauncherConfig.fromEnvironment());
 
-  getIt.registerSingletonAsync<AccessibilityController>(
-      () => AccessibilityController.create());
+  getIt.registerSingletonAsync<AccessibilityController>(() =>
+      AccessibilityController.create(
+          getIt.get<LauncherConfig>().accessibilityOptionIds));
 
   await getIt.allReady();
   runApp(const LauncherApp());

--- a/launcher/lib/models/launcher_config.dart
+++ b/launcher/lib/models/launcher_config.dart
@@ -1,0 +1,64 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:logging/logging.dart';
+
+class LauncherConfig {
+  static const _headEnvKey = 'UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON';
+  static const _tailEnvKey = 'UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON';
+  static const _accessibilityIds = {
+    'magnifier',
+    'cursor-scale',
+    'output-filter',
+  };
+
+  static final _logger = Logger('LauncherConfig');
+
+  final List<String> headItems;
+  final List<String> tailItems;
+
+  LauncherConfig._({required this.headItems, required this.tailItems});
+
+  factory LauncherConfig.fromEnvironment() {
+    final head = _parseEnv(_headEnvKey);
+    final tail = _parseEnv(_tailEnvKey);
+    _logger.info('head=$head tail=$tail');
+    return LauncherConfig._(headItems: head, tailItems: tail);
+  }
+
+  static List<String> _parseEnv(String key) {
+    final value = Platform.environment[key];
+    if (value == null || value.isEmpty) return [];
+    try {
+      final decoded = jsonDecode(value);
+      if (decoded is! List || !decoded.every((item) => item is String)) {
+        throw const FormatException('must be an array of strings');
+      }
+      return decoded.cast<String>();
+    } on FormatException catch (error) {
+      _logger.warning('$key: $error');
+      return [];
+    }
+  }
+
+  List<String> get accessibilityOptionIds => [
+    ...headItems,
+    ...tailItems,
+  ].where((id) => _accessibilityIds.contains(id)).toList();
+}

--- a/launcher/lib/models/launcher_config.dart
+++ b/launcher/lib/models/launcher_config.dart
@@ -47,20 +47,11 @@ class LauncherConfig {
 
   @visibleForTesting
   factory LauncherConfig.fromMap(Map<String, String> environment) {
-    final head = _withoutRunning(_parseEnv(environment, _headEnvKey), 'head');
+    final head = _parseEnv(environment, _headEnvKey);
     final body = _parseEnv(environment, _bodyEnvKey);
-    final tail = _withoutRunning(_parseEnv(environment, _tailEnvKey), 'tail');
+    final tail = _parseEnv(environment, _tailEnvKey);
     _logger.info('head=$head body=$body tail=$tail');
     return LauncherConfig._(headItems: head, bodyItems: body, tailItems: tail);
-  }
-
-  static List<String> _withoutRunning(List<String> items, String group) {
-    if (items.contains('running')) {
-      _logger.warning(
-        "'running' is only supported in body items; ignoring it in $group",
-      );
-    }
-    return items.where((item) => item != 'running').toList();
   }
 
   static List<String> _parseEnv(Map<String, String> environment, String key) {

--- a/launcher/lib/models/launcher_config.dart
+++ b/launcher/lib/models/launcher_config.dart
@@ -17,10 +17,12 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 
 class LauncherConfig {
   static const _headEnvKey = 'UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON';
+  static const _bodyEnvKey = 'UBUNTU_FRAME_LAUNCHER_BODY_ITEMS_JSON';
   static const _tailEnvKey = 'UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON';
   static const _accessibilityIds = {
     'magnifier',
@@ -31,19 +33,38 @@ class LauncherConfig {
   static final _logger = Logger('LauncherConfig');
 
   final List<String> headItems;
+  final List<String> bodyItems;
   final List<String> tailItems;
 
-  LauncherConfig._({required this.headItems, required this.tailItems});
+  LauncherConfig._({
+    required this.headItems,
+    required this.bodyItems,
+    required this.tailItems,
+  });
 
-  factory LauncherConfig.fromEnvironment() {
-    final head = _parseEnv(_headEnvKey);
-    final tail = _parseEnv(_tailEnvKey);
-    _logger.info('head=$head tail=$tail');
-    return LauncherConfig._(headItems: head, tailItems: tail);
+  factory LauncherConfig.fromEnvironment() =>
+      LauncherConfig.fromMap(Platform.environment);
+
+  @visibleForTesting
+  factory LauncherConfig.fromMap(Map<String, String> environment) {
+    final head = _withoutRunning(_parseEnv(environment, _headEnvKey), 'head');
+    final body = _parseEnv(environment, _bodyEnvKey);
+    final tail = _withoutRunning(_parseEnv(environment, _tailEnvKey), 'tail');
+    _logger.info('head=$head body=$body tail=$tail');
+    return LauncherConfig._(headItems: head, bodyItems: body, tailItems: tail);
   }
 
-  static List<String> _parseEnv(String key) {
-    final value = Platform.environment[key];
+  static List<String> _withoutRunning(List<String> items, String group) {
+    if (items.contains('running')) {
+      _logger.warning(
+        "'running' is only supported in body items; ignoring it in $group",
+      );
+    }
+    return items.where((item) => item != 'running').toList();
+  }
+
+  static List<String> _parseEnv(Map<String, String> environment, String key) {
+    final value = environment[key];
     if (value == null || value.isEmpty) return [];
     try {
       final decoded = jsonDecode(value);
@@ -59,6 +80,7 @@ class LauncherConfig {
 
   List<String> get accessibilityOptionIds => [
     ...headItems,
+    ...bodyItems,
     ...tailItems,
   ].where((id) => _accessibilityIds.contains(id)).toList();
 }

--- a/launcher/lib/views/accessibility_button.dart
+++ b/launcher/lib/views/accessibility_button.dart
@@ -20,25 +20,21 @@ import 'package:ubuntu_frame_launcher/controllers/accessibility_controller.dart'
 import 'package:ubuntu_frame_launcher/models/accessibility_option.dart';
 
 class AccessibilityButton extends StatelessWidget {
-  const AccessibilityButton({super.key});
+  final String optionId;
+
+  const AccessibilityButton({super.key, required this.optionId});
 
   @override
   Widget build(BuildContext context) {
     final controller = GetIt.instance.get<AccessibilityController>();
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        ...controller.options.map(
-          (option) => Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: _OptionButton(
-              option: option,
-              onTap: () => controller.cycleForward(option),
-              onLongPress: () => controller.cycleBackward(option),
-            ),
-          ),
-        ),
-      ],
+    final option = controller.options.firstWhere((o) => o.id == optionId);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: _OptionButton(
+        option: option,
+        onTap: () => controller.cycleForward(option),
+        onLongPress: () => controller.cycleBackward(option),
+      ),
     );
   }
 }

--- a/launcher/lib/views/dock.dart
+++ b/launcher/lib/views/dock.dart
@@ -14,9 +14,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'dart:math' show max;
+
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:ubuntu_frame_launcher/controllers/application_controller.dart';
+import 'package:ubuntu_frame_launcher/models/launcher_config.dart';
 import 'package:ubuntu_frame_launcher/views/accessibility_button.dart';
 import 'package:ubuntu_frame_launcher/views/dock_button.dart';
 import 'package:ubuntu_frame_launcher/views/stream_builder_with_future_initial_value.dart';
@@ -29,35 +32,66 @@ class Dock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final applicationController = GetIt.instance.get<ApplicationController>();
+    final config = GetIt.instance.get<LauncherConfig>();
     return Expanded(
-      child: Container(
-        color: Colors.black,
-        width: _dockWidthPx,
-        padding: _dockPadding,
-        child: Column(
-          children: [
-            Expanded(
-              child: StreamBuilderWithFutureInitialValue(
-                  future: applicationController.getOpenApplications(),
-                  stream: applicationController.getOpenedAppsStream(),
-                  loader: const Row(),
-                  builder: (context, openedApps) {
-                    List<Widget> dockButtons = [];
-                    for (final opened in openedApps) {
-                      if (opened.id.isEmpty) {
-                        continue;
-                      }
-                      dockButtons.add(DockButton(desktopFile: opened));
-                    }
-                    return SingleChildScrollView(
-                        child: Column(children: dockButtons));
-                  }),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final fixedItemCount = [...config.headItems, ...config.tailItems]
+              .where((i) => i != 'running')
+              .length;
+          // Each accessibility button is 56px + 4px bottom padding.
+          const itemHeight = 60.0;
+          final runningMaxHeight = max(
+            0.0,
+            constraints.maxHeight - _dockPadding.vertical - fixedItemCount * itemHeight,
+          );
+          return Container(
+            color: Colors.black,
+            width: _dockWidthPx,
+            padding: _dockPadding,
+            child: Column(
+              children: [
+                ..._buildItems(config.headItems, runningMaxHeight),
+                const Spacer(),
+                ..._buildItems(config.tailItems, runningMaxHeight),
+              ],
             ),
-            const AccessibilityButton(),
-          ],
-        ),
+          );
+        },
       ),
+    );
+  }
+
+  List<Widget> _buildItems(List<String> items, double runningMaxHeight) {
+    return items.map<Widget>((item) {
+      if (item == 'running') {
+        return ConstrainedBox(
+          constraints: BoxConstraints(maxHeight: runningMaxHeight),
+          child: const _RunningAppsSection(),
+        );
+      }
+      return AccessibilityButton(optionId: item);
+    }).toList();
+  }
+}
+
+class _RunningAppsSection extends StatelessWidget {
+  const _RunningAppsSection();
+
+  @override
+  Widget build(BuildContext context) {
+    final applicationController = GetIt.instance.get<ApplicationController>();
+    return StreamBuilderWithFutureInitialValue(
+      future: applicationController.getOpenApplications(),
+      stream: applicationController.getOpenedAppsStream(),
+      loader: const Row(),
+      builder: (context, openedApps) {
+        final dockButtons = openedApps
+            .where((app) => app.id.isNotEmpty)
+            .map((app) => DockButton(desktopFile: app))
+            .toList();
+        return SingleChildScrollView(child: Column(children: dockButtons));
+      },
     );
   }
 }

--- a/launcher/lib/views/dock.dart
+++ b/launcher/lib/views/dock.dart
@@ -14,8 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import 'dart:math' show max;
-
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:ubuntu_frame_launcher/controllers/application_controller.dart';
@@ -34,41 +32,29 @@ class Dock extends StatelessWidget {
   Widget build(BuildContext context) {
     final config = GetIt.instance.get<LauncherConfig>();
     return Expanded(
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final fixedItemCount = [...config.headItems, ...config.tailItems]
-              .where((i) => i != 'running')
-              .length;
-          // Each accessibility button is 56px + 4px bottom padding.
-          const itemHeight = 60.0;
-          final runningMaxHeight = max(
-            0.0,
-            constraints.maxHeight - _dockPadding.vertical - fixedItemCount * itemHeight,
-          );
-          return Container(
-            color: Colors.black,
-            width: _dockWidthPx,
-            padding: _dockPadding,
-            child: Column(
-              children: [
-                ..._buildItems(config.headItems, runningMaxHeight),
-                const Spacer(),
-                ..._buildItems(config.tailItems, runningMaxHeight),
-              ],
+      child: Container(
+        color: Colors.black,
+        width: _dockWidthPx,
+        padding: _dockPadding,
+        child: Column(
+          children: [
+            ..._buildItems(config.headItems),
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(children: _buildItems(config.bodyItems)),
+              ),
             ),
-          );
-        },
+            ..._buildItems(config.tailItems),
+          ],
+        ),
       ),
     );
   }
 
-  List<Widget> _buildItems(List<String> items, double runningMaxHeight) {
+  List<Widget> _buildItems(List<String> items) {
     return items.map<Widget>((item) {
       if (item == 'running') {
-        return ConstrainedBox(
-          constraints: BoxConstraints(maxHeight: runningMaxHeight),
-          child: const _RunningAppsSection(),
-        );
+        return const _RunningAppsSection();
       }
       return AccessibilityButton(optionId: item);
     }).toList();
@@ -90,7 +76,7 @@ class _RunningAppsSection extends StatelessWidget {
             .where((app) => app.id.isNotEmpty)
             .map((app) => DockButton(desktopFile: app))
             .toList();
-        return SingleChildScrollView(child: Column(children: dockButtons));
+        return Column(children: dockButtons);
       },
     );
   }

--- a/launcher/test/launcher_config_test.dart
+++ b/launcher/test/launcher_config_test.dart
@@ -1,0 +1,84 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:ubuntu_frame_launcher/models/launcher_config.dart';
+
+void main() {
+  group('LauncherConfig', () {
+    test('parses head, body and tail items', () {
+      final config = LauncherConfig.fromMap({
+        'UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON': '["magnifier"]',
+        'UBUNTU_FRAME_LAUNCHER_BODY_ITEMS_JSON': '["running"]',
+        'UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON': '["cursor-scale"]',
+      });
+
+      expect(config.headItems, ['magnifier']);
+      expect(config.bodyItems, ['running']);
+      expect(config.tailItems, ['cursor-scale']);
+    });
+
+    test('defaults each group to an empty list when unset', () {
+      final config = LauncherConfig.fromMap({});
+
+      expect(config.headItems, isEmpty);
+      expect(config.bodyItems, isEmpty);
+      expect(config.tailItems, isEmpty);
+    });
+
+    test('drops running from head and tail, keeping it only in body', () {
+      final config = LauncherConfig.fromMap({
+        'UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON': '["running","magnifier"]',
+        'UBUNTU_FRAME_LAUNCHER_BODY_ITEMS_JSON': '["running"]',
+        'UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON': '["cursor-scale","running"]',
+      });
+
+      expect(config.headItems, ['magnifier']);
+      expect(config.bodyItems, ['running']);
+      expect(config.tailItems, ['cursor-scale']);
+    });
+
+    test('defaults body to empty when only head and tail are set', () {
+      final config = LauncherConfig.fromMap({
+        'UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON': '["magnifier"]',
+        'UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON': '["cursor-scale"]',
+      });
+
+      expect(config.headItems, ['magnifier']);
+      expect(config.bodyItems, isEmpty);
+      expect(config.tailItems, ['cursor-scale']);
+    });
+
+    test('collects accessibility ids across head, body and tail', () {
+      final config = LauncherConfig.fromMap({
+        'UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON': '["magnifier","running"]',
+        'UBUNTU_FRAME_LAUNCHER_BODY_ITEMS_JSON': '["running","cursor-scale"]',
+        'UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON': '["output-filter"]',
+      });
+
+      expect(config.accessibilityOptionIds,
+          ['magnifier', 'cursor-scale', 'output-filter']);
+    });
+
+    test('falls back to empty list on malformed json', () {
+      final config = LauncherConfig.fromMap({
+        'UBUNTU_FRAME_LAUNCHER_BODY_ITEMS_JSON': '"magnifier"]',
+      });
+
+      expect(config.bodyItems, isEmpty);
+    });
+  });
+}

--- a/launcher/test/launcher_config_test.dart
+++ b/launcher/test/launcher_config_test.dart
@@ -39,18 +39,6 @@ void main() {
       expect(config.tailItems, isEmpty);
     });
 
-    test('drops running from head and tail, keeping it only in body', () {
-      final config = LauncherConfig.fromMap({
-        'UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON': '["running","magnifier"]',
-        'UBUNTU_FRAME_LAUNCHER_BODY_ITEMS_JSON': '["running"]',
-        'UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON': '["cursor-scale","running"]',
-      });
-
-      expect(config.headItems, ['magnifier']);
-      expect(config.bodyItems, ['running']);
-      expect(config.tailItems, ['cursor-scale']);
-    });
-
     test('defaults body to empty when only head and tail are set', () {
       final config = LauncherConfig.fromMap({
         'UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON': '["magnifier"]',

--- a/scripts/bin/run-launcher
+++ b/scripts/bin/run-launcher
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -eu
 
-if UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_OPTIONS="$(snapctl get launcher.tail 2>/dev/null)"; then
-  export UBUNTU_FRAME_LAUNCHER_ACCESSIBILITY_OPTIONS
+if launcher_head="$(snapctl get launcher.head 2>/dev/null)"; then
+  export UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON="$launcher_head"
+fi
+if launcher_tail="$(snapctl get launcher.tail 2>/dev/null)"; then
+  export UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON="$launcher_tail"
 fi
 exec "$@"

--- a/scripts/bin/run-launcher
+++ b/scripts/bin/run-launcher
@@ -4,6 +4,9 @@ set -eu
 if launcher_head="$(snapctl get launcher.head 2>/dev/null)"; then
   export UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON="$launcher_head"
 fi
+if launcher_body="$(snapctl get launcher.body 2>/dev/null)"; then
+  export UBUNTU_FRAME_LAUNCHER_BODY_ITEMS_JSON="$launcher_body"
+fi
 if launcher_tail="$(snapctl get launcher.tail 2>/dev/null)"; then
   export UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON="$launcher_tail"
 fi

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -142,10 +142,11 @@ case "$launcher_val" in
     if ! launcher_items="$(printf '%s' "$launcher_val" | jq -er '
       if type != "object" then error("launcher must be an object")
       elif (.head | type) != "array" then error("launcher.head must be an array")
+      elif ((.body // []) | type) != "array" then error("launcher.body must be an array")
       elif (.tail | type) != "array" then error("launcher.tail must be an array")
-      else .head[], .tail[] end
+      else .head[], (.body // [])[], .tail[] end
     ')"; then
-      echo "ERROR: launcher must be an object with head and tail arrays"
+      echo "ERROR: launcher must be an object with head, body and tail arrays"
       exit 1
     fi
     invalid_items=""
@@ -164,7 +165,7 @@ case "$launcher_val" in
     launcher_enabled=false
     ;;
   *)
-    echo "ERROR: launcher must be a JSON object with head and tail arrays"
+    echo "ERROR: launcher must be a JSON object with head, body and tail arrays"
     exit 1
     ;;
 esac

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -134,41 +134,37 @@ else
   snapctl stop --disable "$SNAP_INSTANCE_NAME.daemon" 2>&1 || true
 fi
 
-validate_launcher_tail() {
-  local tail="$1"
-  [ -z "$tail" ] && return 0
-  local IFS=','
-  for element in $tail; do
-    case "$element" in
-      magnifier|cursor-scale|output-filter) ;;
-      *) return 1 ;;
-    esac
-  done
-  return 0
-}
-
-# Validate and process launcher option
-# launcher can be: "true", "false", or a JSON object e.g. {"tail":["magnifier","cursor-scale"]}
-# When set as an object, snapctl exposes launcher.tail as a comma-separated list already.
+# Validate and process launcher option.
 launcher_val="$(snapctl get launcher)"
 launcher_enabled=false
 case "$launcher_val" in
-  true)
-    launcher_enabled=true
-    ;;
-  false|"")
-    launcher_enabled=false
-    ;;
   {*)
-    launcher_enabled=true
-    launcher_tail="$(snapctl get launcher.tail)"
-    if ! validate_launcher_tail "$launcher_tail"; then
-      echo "ERROR: launcher.tail must be a list of zero or more of: magnifier, cursor-scale, output-filter"
+    if ! launcher_items="$(printf '%s' "$launcher_val" | jq -er '
+      if type != "object" then error("launcher must be an object")
+      elif (.head | type) != "array" then error("launcher.head must be an array")
+      elif (.tail | type) != "array" then error("launcher.tail must be an array")
+      else .head[], .tail[] end
+    ')"; then
+      echo "ERROR: launcher must be an object with head and tail arrays"
       exit 1
     fi
+    invalid_items=""
+    if [ -n "$launcher_items" ]; then
+      invalid_items="$(printf '%s\n' "$launcher_items" | grep -vxE 'running|magnifier|cursor-scale|output-filter' || true)"
+    fi
+    if [ -n "$invalid_items" ]; then
+      echo "ERROR: launcher items must be running, magnifier, cursor-scale, or output-filter"
+      exit 1
+    fi
+    if [ -n "$launcher_items" ]; then
+      launcher_enabled=true
+    fi
+    ;;
+  "")
+    launcher_enabled=false
     ;;
   *)
-    echo "ERROR: launcher must be true, false, or a JSON object"
+    echo "ERROR: launcher must be a JSON object with head and tail arrays"
     exit 1
     ;;
 esac
@@ -179,12 +175,6 @@ if [ "$launcher_enabled" = "true" ]; then
   if [[ "$ARCH" != @(x86_64*|i*86|aarch64) ]]; then
     echo "Cannot enable the launcher on $ARCH system"
     exit 1
-  fi
-
-  if ! snapctl is-connected desktop-launch; then
-    echo "Please connect the "desktop-launch" interface:"
-    echo "  sudo snap connect $SNAP_INSTANCE_NAME:desktop-launch"
-    exit 2
   fi
 
   if snapctl services "$SNAP_INSTANCE_NAME.launcher" | grep -q inactive; then

--- a/snap/hooks/disconnect-plug-desktop-launch
+++ b/snap/hooks/disconnect-plug-desktop-launch
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -eux
-
-# Disable the launcher to avoid subsequent configure issues
-snapctl stop --disable $SNAP_INSTANCE_NAME.launcher
-snapctl set launcher=false

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,5 +17,5 @@ fi
 launcher=$(snapctl get launcher)
 if [ "$launcher" = "" ]
 then
-  snapctl set launcher=false
+  snapctl set launcher='{"head":[],"tail":[]}'
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -17,5 +17,5 @@ fi
 launcher=$(snapctl get launcher)
 if [ "$launcher" = "" ]
 then
-  snapctl set launcher='{"head":[],"tail":[]}'
+  snapctl set launcher='{"head":[],"body":[],"tail":[]}'
 fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -177,6 +177,7 @@ parts:
     source: scripts
     stage-packages:
       - inotify-tools
+      - jq
 
   anon-shm-preload:
     source: https://github.com/MirServer/anon-shm-preload.git


### PR DESCRIPTION
Deprecate `true`/`false` values for the launcher and require valid JSON objects instead.

---

To test, use the newly introduced workshop:

```
workshop run \
  --env UBUNTU_FRAME_LAUNCHER_TAIL_ITEMS_JSON='["running","magnifier"]' \
  --env UBUNTU_FRAME_LAUNCHER_HEAD_ITEMS_JSON='["running","cursor-scale"]' \
  frame
```